### PR TITLE
🔒 [security fix] Fix path traversal in MIDI export

### DIFF
--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -38,6 +38,18 @@ def _generate_midi_filename_helper(tonic: str, scale_info: Dict[str, Any], base_
     return os.path.join(base_dir, filename)
 
 
+def _sanitize_midi_path(path_input: str, default_path: str, base_dir: str) -> str:
+    """
+    Sanitizes the user-provided path to prevent path traversal vulnerabilities.
+    If path_input is empty, it returns the default_path.
+    Otherwise, it extracts only the filename and joins it with the intended base directory.
+    """
+    if not path_input:
+        return default_path
+    filename = os.path.basename(path_input)
+    return os.path.join(base_dir, filename)
+
+
 def main():
     # Initialize colorama for cross-platform color support
     colorama.init()
@@ -173,9 +185,8 @@ def main():
 
         suggested_midi_path = _generate_midi_filename_helper(selected_scale_tonic, selected_scale_info, midi_export_default_dir)
 
-        output_midi_filename = input(f"Enter MIDI filename [default: {suggested_midi_path}]: ").strip()
-        if not output_midi_filename:
-            output_midi_filename = suggested_midi_path
+        output_midi_filename_in = input(f"Enter MIDI filename [default: {suggested_midi_path}]: ").strip()
+        output_midi_filename = _sanitize_midi_path(output_midi_filename_in, suggested_midi_path, midi_export_default_dir)
 
         midi_builder.generate_midi_file(chords_for_midi_processing, output_midi_filename, advanced_midi_opts)
 
@@ -210,10 +221,9 @@ def main():
                             if transposed_chords_for_midi:
                                 sugg_trans_path = _generate_midi_filename_helper(new_tonic, new_scale_data, midi_export_default_dir, prefix="prog_TRANSP_")
 
-                                trans_midi_fname_out = input(
+                                trans_midi_fname_out_in = input(
                                     f"Enter transposed MIDI filename [default: {sugg_trans_path}]: ").strip()
-                                if not trans_midi_fname_out:
-                                    trans_midi_fname_out = sugg_trans_path
+                                trans_midi_fname_out = _sanitize_midi_path(trans_midi_fname_out_in, sugg_trans_path, midi_export_default_dir)
                                 midi_builder.generate_midi_file(transposed_chords_for_midi, trans_midi_fname_out,
                                                                 advanced_midi_opts)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,45 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock colorama
+sys.modules['colorama'] = MagicMock()
+sys.modules['colorama.Fore'] = MagicMock()
+sys.modules['colorama.Style'] = MagicMock()
+
+# Mock mido (needed by generators which is imported by chorderizer)
+sys.modules['mido'] = MagicMock()
+
+import os
+import unittest
+from chorderizer.chorderizer import _sanitize_midi_path
+
+class TestSecurity(unittest.TestCase):
+    def setUp(self):
+        self.base_dir = "/home/user/midi_exports"
+        self.default_path = os.path.join(self.base_dir, "default.mid")
+
+    def test_sanitize_empty_input(self):
+        result = _sanitize_midi_path("", self.default_path, self.base_dir)
+        self.assertEqual(result, self.default_path)
+
+    def test_sanitize_normal_filename(self):
+        result = _sanitize_midi_path("my_song.mid", self.default_path, self.base_dir)
+        self.assertEqual(result, os.path.join(self.base_dir, "my_song.mid"))
+
+    def test_sanitize_path_traversal(self):
+        # On Linux, os.path.basename("../../../etc/passwd") is "passwd"
+        result = _sanitize_midi_path("../../../etc/passwd", self.default_path, self.base_dir)
+        self.assertEqual(result, os.path.join(self.base_dir, "passwd"))
+
+    def test_sanitize_absolute_path(self):
+        # On Linux, os.path.basename("/tmp/evil.mid") is "evil.mid"
+        result = _sanitize_midi_path("/tmp/evil.mid", self.default_path, self.base_dir)
+        self.assertEqual(result, os.path.join(self.base_dir, "evil.mid"))
+
+    def test_sanitize_nested_traversal(self):
+        # os.path.basename("subdir/../other.mid") is "other.mid"
+        result = _sanitize_midi_path("subdir/../other.mid", self.default_path, self.base_dir)
+        self.assertEqual(result, os.path.join(self.base_dir, "other.mid"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in the MIDI export feature.
⚠️ **Risk:** Attackers could provide malicious file paths (e.g., `../../../etc/passwd`) to create or overwrite files outside of the intended MIDI export directory.
🛡️ **Solution:** Implemented a `_sanitize_midi_path` helper function that extracts only the filename from user input and joins it with the safe base directory. This was applied to both the primary and transposed MIDI export functions.
✅ **Verification:** Added a new test suite (`tests/test_security.py`) and verified all tests pass.


---
*PR created automatically by Jules for task [17294993103999658571](https://jules.google.com/task/17294993103999658571) started by @julesklord*