### PR TITLE
🧹 Remove commented-out import and notes in theory_utils.py

### DIFF
--- a/src/chorderizer/theory_utils.py
+++ b/src/chorderizer/theory_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple, Optional, Any, Union, Mapping
+from typing import List, Dict, Tuple, Optional, Any
 
 # -----------------------------------------------------------------------------
 # Class MusicTheoryUtils: Utility functions for music theory
@@ -249,11 +249,3 @@ class MusicTheory:
         90: "Synth Pad 3 (polysynth)"
     }
 
-# Ensure Mapping is available if used by get_numbered_option if it were moved here.
-# For now, it's fine as MusicTheory itself does not use Mapping directly in its annotations.
-# If get_note_name or get_note_index were to use Mapping, it would be needed.
-# The original chorderizer.py used Union for get_numbered_option's `options` parameter,
-# which might be Dict[str, Any] or Dict[int, Any].
-# So, `Mapping` is a good general type hint for options in get_numbered_option.
-# `MusicTheory` uses `Dict[str, Any]` and `Dict[int, str]` which are compatible.
-# Adding `Mapping` to the import list for completeness, though not strictly used by these two classes directly.


### PR DESCRIPTION
### 🎯 What:
Removed a block of commented-out notes and unused `Union` and `Mapping` imports from `src/chorderizer/theory_utils.py`.

### 💡 Why:
These comments and imports were explicitly noted as being for "completeness" or for hypothetical future use. Removing them improves the readability and maintainability of the codebase by eliminating dead code and unnecessary clutter.

### ✅ Verification:
- Successfully ran `PYTHONPATH=src pytest` and verified that all 5 tests passed.
- Performed a code review, which confirmed the changes are correct and safe.

### ✨ Result:
A cleaner `theory_utils.py` file without unused imports and obsolete comments.

---
*PR created automatically by Jules for task [17382603658736290987](https://jules.google.com/task/17382603658736290987) started by @julesklord*