### PR TITLE
🧪 [Add tests for _generate_midi_filename_helper]

### DIFF
--- a/tests/test_chorderizer.py
+++ b/tests/test_chorderizer.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock
+
+# Mock colorama and mido before importing chorderizer
+sys.modules['colorama'] = MagicMock()
+sys.modules['mido'] = MagicMock()
+
+from chorderizer.chorderizer import _generate_midi_filename_helper
+
+def test_generate_midi_filename_helper_basic():
+    tonic = "C"
+    scale_info = {"name": "Major"}
+    base_dir = "/tmp/midi"
+
+    expected_filename = "prog_C_Major.mid"
+    expected_path = os.path.join(base_dir, expected_filename)
+
+    assert _generate_midi_filename_helper(tonic, scale_info, base_dir) == expected_path
+
+def test_generate_midi_filename_helper_with_spaces_in_tonic():
+    tonic = "C # "
+    scale_info = {"name": "Major"}
+    base_dir = "/tmp/midi"
+
+    expected_filename = "prog_C_#__Major.mid"
+    expected_path = os.path.join(base_dir, expected_filename)
+
+    assert _generate_midi_filename_helper(tonic, scale_info, base_dir) == expected_path
+
+def test_generate_midi_filename_helper_with_parentheses_and_spaces_in_scale():
+    tonic = "D"
+    scale_info = {"name": "Minor (Harmonic)"}
+    base_dir = "/tmp/midi"
+
+    expected_filename = "prog_D_Minor_Harmonic.mid"
+    expected_path = os.path.join(base_dir, expected_filename)
+
+    assert _generate_midi_filename_helper(tonic, scale_info, base_dir) == expected_path
+
+def test_generate_midi_filename_helper_custom_prefix():
+    tonic = "G"
+    scale_info = {"name": "Dorian"}
+    base_dir = "/tmp/midi"
+    prefix = "custom_"
+
+    expected_filename = "custom_G_Dorian.mid"
+    expected_path = os.path.join(base_dir, expected_filename)
+
+    assert _generate_midi_filename_helper(tonic, scale_info, base_dir, prefix=prefix) == expected_path
+
+def test_generate_midi_filename_helper_empty_base_dir():
+    tonic = "A"
+    scale_info = {"name": "Phrygian"}
+    base_dir = ""
+
+    expected_filename = "prog_A_Phrygian.mid"
+    expected_path = os.path.join(base_dir, expected_filename)
+
+    assert _generate_midi_filename_helper(tonic, scale_info, base_dir) == expected_path


### PR DESCRIPTION
🎯 **What:** The testing gap for `_generate_midi_filename_helper` in `src/chorderizer/chorderizer.py` has been addressed. The function logic (formatting of MIDI file names safely) previously lacked any testing.

📊 **Coverage:** The following scenarios are now tested:
- Normal case with standard tonic and scale name.
- Tonic containing spaces (`replace(' ', '_')` logic).
- Scale name containing spaces and parentheses (`replace('(', '').replace(')', '')` logic).
- Custom `prefix` argument overriding the default `prog_`.
- Empty `base_dir` handling.

✨ **Result:** Increased code reliability and testing coverage for the filename generation string manipulations, with tests that run deterministically using dependency mocking for missing modules in limited environments.

---
*PR created automatically by Jules for task [5263139514413077952](https://jules.google.com/task/5263139514413077952) started by @julesklord*