### PR TITLE
🔒 Fix unrestricted path traversal in MIDI export

### DIFF
--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -176,6 +176,8 @@ def main():
         output_midi_filename = input(f"Enter MIDI filename [default: {suggested_midi_path}]: ").strip()
         if not output_midi_filename:
             output_midi_filename = suggested_midi_path
+        else:
+            output_midi_filename = os.path.join(midi_export_default_dir, os.path.basename(output_midi_filename))
 
         midi_builder.generate_midi_file(chords_for_midi_processing, output_midi_filename, advanced_midi_opts)
 
@@ -214,6 +216,8 @@ def main():
                                     f"Enter transposed MIDI filename [default: {sugg_trans_path}]: ").strip()
                                 if not trans_midi_fname_out:
                                     trans_midi_fname_out = sugg_trans_path
+                                else:
+                                    trans_midi_fname_out = os.path.join(midi_export_default_dir, os.path.basename(trans_midi_fname_out))
                                 midi_builder.generate_midi_file(transposed_chords_for_midi, trans_midi_fname_out,
                                                                 advanced_midi_opts)
 


### PR DESCRIPTION
🎯 What:
Fixed an unrestricted path traversal vulnerability in `chorderizer.py` where a user-provided MIDI filename was directly passed to the output file generator.

⚠️ Risk:
A malicious user could provide a filename containing directory traversal sequences (e.g., `../../../etc/passwd` or absolute paths) to write arbitrary files to unauthorized locations on the system.

🛡️ Solution:
Sanitized user input by extracting only the filename using `os.path.basename` and joined it securely with the designated `midi_export_default_dir`. The fix handles both regular and transposed MIDI export operations.

---
*PR created automatically by Jules for task [216058005527364053](https://jules.google.com/task/216058005527364053) started by @julesklord*