### PR TITLE
🎨 Palette: Enhance CLI color contrast and interaction

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-04 - Handle CLI interruptions gracefully
 **Learning:** KeyboardInterrupt (Ctrl+C) or EOFError (Ctrl+D) in command line input prompts normally crash the program and print ugly tracebacks. Wrapping the `input()` call in a `try...except` block with a cancellation message improves the user experience significantly.
 **Action:** Always wrap `input()` prompts in a `try...except` block to gracefully handle early exit signals.
+
+## 2024-05-18 - Terminal Color Contrast
+**Learning:** Standard terminal blue (`Fore.BLUE` from colorama) often has poor contrast against dark backgrounds commonly used by developers, making text hard to read.
+**Action:** Prefer `Fore.CYAN` or lighter shades for blue-related highlights in terminal outputs to ensure better readability and accessibility.

--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -98,7 +98,7 @@ def main():
             base_qual = gen_base_qualities.get(degree)
             color_code = Fore.GREEN
             if base_qual == "minor":
-                color_code = Fore.BLUE
+                color_code = Fore.CYAN
             elif base_qual == "diminished" or "ø" in chord_name_display or "m7b5" in chord_name_display:
                 color_code = Fore.MAGENTA
             elif base_qual == "augmented" or "+" in chord_name_display:

--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -224,7 +224,7 @@ def main():
                             if transposed_chords_for_midi:
                                 sugg_trans_path = _generate_midi_filename_helper(new_tonic, new_scale_data, midi_export_default_dir, prefix="prog_TRANSP_")
 
-                                trans_midi_fname_out_in = input(
+                                trans_midi_fname_out = input(
                                     f"Enter transposed MIDI filename [default: {sugg_trans_path}]: ").strip()
                                 if not trans_midi_fname_out:
                                     trans_midi_fname_out = sugg_trans_path

--- a/src/chorderizer/ui.py
+++ b/src/chorderizer/ui.py
@@ -19,10 +19,11 @@ def print_operation_cancelled() -> None:
 def get_yes_no_answer(prompt: str) -> bool:
     while True:
         try:
-            response = input(f"{Fore.BLUE}{prompt} (yes/no): {Style.RESET_ALL}").strip().lower()
+            response = input(f"{Fore.CYAN}{prompt} [y/N]: {Style.RESET_ALL}").strip().lower()
+            if not response: return False
             if response in ["yes", "y", "si", "s"]: return True
             if response in ["no", "n"]: return False
-            print(f"{Fore.RED}Invalid response. Please enter 'yes' or 'no'.{Style.RESET_ALL}")
+            print(f"{Fore.RED}Invalid response. Please enter 'y' or 'n'.{Style.RESET_ALL}")
         except (EOFError, KeyboardInterrupt):
             print_operation_cancelled()
             sys.exit(0)


### PR DESCRIPTION
💡 What: Replaced standard terminal blue (`Fore.BLUE`) with cyan (`Fore.CYAN`) in the UI and updated the `[y/n]` prompt to be clearer, safely defaulting to 'No' on empty input.
🎯 Why: Standard terminal blue has terrible contrast on dark backgrounds and is difficult to read. In addition, the boolean prompt was missing a safe default on Enter, risking loop traps. 
📸 Before/After: Visual changes in CLI colors from dark blue to bright cyan, prompt updated from `(yes/no)` to `[y/N]`.
♿ Accessibility: Improved reading experience for visually impaired developers using standard dark theme terminals. Added an entry to `.Jules/palette.md` for team visibility on color contrast in CLIs.

---
*PR created automatically by Jules for task [2291073356823578541](https://jules.google.com/task/2291073356823578541) started by @julesklord*