### PR TITLE
🎨 Palette: Handle CLI interruptions gracefully

### DIFF
--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import random
 from typing import List, Dict, Tuple, Optional, Any
 import colorama
@@ -239,4 +240,8 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except (EOFError, KeyboardInterrupt):
+        print_operation_cancelled()
+        sys.exit(0)


### PR DESCRIPTION
💡 What: Wrapped the execution of `main()` in `src/chorderizer/chorderizer.py` with a `try...except (EOFError, KeyboardInterrupt)` block that exits gracefully using `sys.exit(0)`.
🎯 Why: Without this, exiting the CLI program via `Ctrl+C` or `Ctrl+D` causes a confusing and unseemly Python `KeyboardInterrupt` traceback to print directly to the user's terminal. This cleans up the experience by printing a user-friendly cancellation message and returning correctly.
📸 Before/After: Before: Raw python stack trace on exit. After: "Operation cancelled by the user." with 0 exit code.
♿ Accessibility: Better CLI robustness and clearer textual cues instead of raw error dumps.

---
*PR created automatically by Jules for task [2372515719023837352](https://jules.google.com/task/2372515719023837352) started by @julesklord*