### PR TITLE
🎨 Palette: Graceful CLI exit and colorization

### DIFF
--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -1,6 +1,5 @@
 import os
-import random
-from typing import List, Dict, Tuple, Optional, Any
+from typing import List, Dict, Any
 import colorama
 from colorama import Fore, Style
 
@@ -9,12 +8,12 @@ from .theory_utils import MusicTheory, MusicTheoryUtils
 from .ui import (
     UIManager,
     print_welcome_message,
-    print_operation_cancelled, 
+    print_operation_cancelled,
     get_yes_no_answer,
-    get_numbered_option, 
+
     get_chord_settings,
     get_tablature_filter,
-    safe_input
+    safe_input,
 )
 from .generators import ChordGenerator, TablatureGenerator, MidiGenerator
 
@@ -24,10 +23,14 @@ from .generators import ChordGenerator, TablatureGenerator, MidiGenerator
 # -----------------------------------------------------------------------------
 # Main Program Logic (Remains in chorderizer.py)
 # -----------------------------------------------------------------------------
-def _generate_midi_filename_helper(tonic: str, scale_info: Dict[str, Any], base_dir: str, prefix: str = "prog_") -> str:
+def _generate_midi_filename_helper(
+    tonic: str, scale_info: Dict[str, Any], base_dir: str, prefix: str = "prog_"
+) -> str:
     # Cleaner filename: keep the b/sharp symbols but make them filename-safe if needed
-    clean_tonic = tonic.replace(' ', '_')
-    safe_scale_name = scale_info['name'].replace(' ', '_').replace('(', '').replace(')', '')
+    clean_tonic = tonic.replace(" ", "_")
+    safe_scale_name = (
+        scale_info["name"].replace(" ", "_").replace("(", "").replace(")", "")
+    )
     filename = f"{prefix}{clean_tonic}_{safe_scale_name}.mid"
     return os.path.join(base_dir, filename)
 
@@ -44,7 +47,9 @@ def _sanitize_midi_path(path_input: str, default_path: str, base_dir: str) -> st
     return os.path.join(base_dir, filename)
 
 
-def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export_default_dir) -> bool:
+def process_single_run(
+    ui, chord_builder, tab_builder, midi_builder, midi_export_default_dir
+) -> bool:
     """Handles one full cycle of chord/MIDI generation. Returns True to continue, False to exit."""
     print("\n" + "=" * 70)
     selected_scale_tonic, selected_scale_info = ui.select_tonic_and_scale()
@@ -54,22 +59,27 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
     chord_settings_tuple = get_chord_settings()
     if chord_settings_tuple is None:
         return True  # User cancelled settings, but might want to try another scale
-    
+
     selected_extension_lvl, selected_inversion_idx = chord_settings_tuple
 
     # Generate chords for the selected scale
-    gen_chord_names, gen_note_names, gen_midi_notes, gen_base_qualities = \
+    gen_chord_names, gen_note_names, gen_midi_notes, gen_base_qualities = (
         chord_builder.generate_scale_chords(
-            selected_scale_tonic, selected_scale_info,
-            selected_extension_lvl, selected_inversion_idx
+            selected_scale_tonic,
+            selected_scale_info,
+            selected_extension_lvl,
+            selected_inversion_idx,
         )
+    )
 
     if not gen_chord_names:
         print(f"\033[31mCould not generate chords for {selected_scale_tonic}.\033[0m")
         return True
 
     print(
-        f"\n{Fore.GREEN}Chords generated for the scale of {selected_scale_tonic} ({selected_scale_info['name']}):{Style.RESET_ALL}")
+        f"\n{Fore.GREEN}Chords generated for the scale of "
+        f"{selected_scale_tonic} ({selected_scale_info['name']}):{Style.RESET_ALL}"
+    )
 
     tab_display_filter_key = get_tablature_filter()
 
@@ -78,7 +88,11 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
         color_code = Fore.GREEN
         if base_qual == "minor":
             color_code = Fore.CYAN
-        elif base_qual == "diminished" or "ø" in chord_name_display or "m7b5" in chord_name_display:
+        elif (
+            base_qual == "diminished"
+            or "ø" in chord_name_display
+            or "m7b5" in chord_name_display
+        ):
             color_code = Fore.MAGENTA
         elif base_qual == "augmented" or "+" in chord_name_display:
             color_code = Fore.YELLOW
@@ -87,7 +101,8 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
         midi_notes_str = ", ".join(map(str, gen_midi_notes.get(degree, [])))
         print(
             f"  {degree.ljust(5)}: {color_code}{chord_name_display.ljust(15)}{Style.RESET_ALL} "
-            f"(Notes: {note_names_str.ljust(25)}) (MIDI: {midi_notes_str})")
+            f"(Notes: {note_names_str.ljust(25)}) (MIDI: {midi_notes_str})"
+        )
 
         show_this_tab = False
         if tab_display_filter_key == "8":
@@ -102,7 +117,9 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
             elif tab_display_filter_key == "4" and "9" in chord_name_display:
                 show_this_tab = True
             elif tab_display_filter_key == "5":
-                if chord_name_display.endswith("6") and not chord_name_display.endswith("m7b6"):
+                if chord_name_display.endswith("6") and not chord_name_display.endswith(
+                    "m7b6"
+                ):
                     show_this_tab = True
             elif tab_display_filter_key == "6" and "11" in chord_name_display:
                 show_this_tab = True
@@ -110,103 +127,160 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
                 show_this_tab = True
 
         if show_this_tab and gen_midi_notes.get(degree):
-            tab_lines_list = tab_builder.generate_simple_tab(chord_name_display, gen_midi_notes[degree])
+            tab_lines_list = tab_builder.generate_simple_tab(
+                chord_name_display, gen_midi_notes[degree]
+            )
             for tab_line in tab_lines_list:
                 print(f"    {tab_line}")
 
     print("\n\033[36m--- MIDI Generation Options ---\033[0m")
     chords_for_midi_processing: List[Dict[str, Any]] = []
     if get_yes_no_answer(
-            "Define a chord progression for MIDI? (If no, all diatonic chords will be used sequentially)"):
-        progression_input_str = safe_input(
-            f"{Fore.CYAN}Enter progression (degrees separated by '-', e.g., I-V-vi-IV). "
-            f"Optional duration in beats (e.g., I:4-V:2-vi:2-IV:4 ): {Style.RESET_ALL}"
-        ).strip().upper()
-        progression_items = progression_input_str.split('-')
+        "Define a chord progression for MIDI? (If no, all diatonic chords will be used sequentially)"
+    ):
+        progression_input_str = (
+            safe_input(
+                f"{Fore.CYAN}Enter progression (degrees separated by '-', e.g., I-V-vi-IV). "
+                f"Optional duration in beats (e.g., I:4-V:2-vi:2-IV:4 ): {Style.RESET_ALL}"
+            )
+            .strip()
+            .upper()
+        )
+        progression_items = progression_input_str.split("-")
         for item_str in progression_items:
             item_str = item_str.strip()
-            if not item_str: continue
+            if not item_str:
+                continue
 
             current_prog_degree, current_beats_duration = item_str, 4.0
             if ":" in item_str:
-                parts = item_str.split(':', 1)
+                parts = item_str.split(":", 1)
                 current_prog_degree = parts[0].strip()
                 try:
                     current_beats_duration = float(parts[1].strip())
-                    if current_beats_duration <= 0: current_beats_duration = 4.0
+                    if current_beats_duration <= 0:
+                        current_beats_duration = 4.0
                 except ValueError:
-                    print(f"\033[31mInvalid duration for '{current_prog_degree}', using 4.0 beats.\033[0m")
+                    print(
+                        f"\033[31mInvalid duration for '{current_prog_degree}', using 4.0 beats.\033[0m"
+                    )
 
             if current_prog_degree in gen_chord_names:
-                chords_for_midi_processing.append({
-                    "grado": current_prog_degree,
-                    "nombre": gen_chord_names[current_prog_degree],
-                    "notas_midi": gen_midi_notes[current_prog_degree],
-                    "duracion_beats": current_beats_duration
-                })
+                chords_for_midi_processing.append(
+                    {
+                        "grado": current_prog_degree,
+                        "nombre": gen_chord_names[current_prog_degree],
+                        "notas_midi": gen_midi_notes[current_prog_degree],
+                        "duracion_beats": current_beats_duration,
+                    }
+                )
             else:
-                print(f"\033[31mDegree '{current_prog_degree}' not found in generated chords. Skipping.\033[0m")
+                print(
+                    f"\033[31mDegree '{current_prog_degree}' not found in generated chords. Skipping.\033[0m"
+                )
     else:
         for degree_key in selected_scale_info["degrees"].keys():
             if degree_key in gen_chord_names:
-                chords_for_midi_processing.append({
-                    "grado": degree_key,
-                    "nombre": gen_chord_names[degree_key],
-                    "notas_midi": gen_midi_notes[degree_key],
-                    "duracion_beats": 2.0
-                })
+                chords_for_midi_processing.append(
+                    {
+                        "grado": degree_key,
+                        "nombre": gen_chord_names[degree_key],
+                        "notas_midi": gen_midi_notes[degree_key],
+                        "duracion_beats": 2.0,
+                    }
+                )
 
     if not chords_for_midi_processing:
         print("\033[31mNo chords selected for MIDI processing.\033[0m")
         return True
 
     advanced_midi_opts = ui.get_advanced_midi_options()
-    suggested_midi_path = _generate_midi_filename_helper(selected_scale_tonic, selected_scale_info, midi_export_default_dir)
+    suggested_midi_path = _generate_midi_filename_helper(
+        selected_scale_tonic, selected_scale_info, midi_export_default_dir
+    )
 
-    output_midi_filename = safe_input(f"{Fore.CYAN}Enter MIDI filename [default: {suggested_midi_path}]: {Style.RESET_ALL}").strip()
+    output_midi_filename = safe_input(
+        f"{Fore.CYAN}Enter MIDI filename [default: {suggested_midi_path}]: {Style.RESET_ALL}"
+    ).strip()
     if not output_midi_filename:
         output_midi_filename = suggested_midi_path
     else:
-        output_midi_filename = os.path.join(midi_export_default_dir, os.path.basename(output_midi_filename))
+        output_midi_filename = os.path.join(
+            midi_export_default_dir, os.path.basename(output_midi_filename)
+        )
 
-    midi_builder.generate_midi_file(chords_for_midi_processing, output_midi_filename, advanced_midi_opts)
+    midi_builder.generate_midi_file(
+        chords_for_midi_processing, output_midi_filename, advanced_midi_opts
+    )
 
     if get_yes_no_answer("Transpose these chord names to another scale tonic?"):
         print(f"\n{Fore.CYAN}--- Transposition ---{Style.RESET_ALL}")
         new_tonic, new_scale_data = ui.select_tonic_and_scale()
         if new_tonic and new_scale_data:
-            transposed_chord_display_names = MusicTheoryUtils.transpose_chords(gen_chord_names, selected_scale_tonic, new_tonic)
+            transposed_chord_display_names = MusicTheoryUtils.transpose_chords(
+                gen_chord_names, selected_scale_tonic, new_tonic
+            )
             if transposed_chord_display_names:
-                print(f"\n{Fore.GREEN}Chord names transposed to the tonic of {new_tonic}:{Style.RESET_ALL}")
+                print(
+                    f"\n{Fore.GREEN}Chord names transposed to the tonic of {new_tonic}:{Style.RESET_ALL}"
+                )
                 for degree, trans_name in transposed_chord_display_names.items():
                     print(f"  {degree.ljust(5)}: {trans_name}")
 
-                if get_yes_no_answer("Generate MIDI for these chords in the NEW key/scale?"):
-                    trans_chord_names_actual, _, trans_midi_notes_actual, _ = \
+                if get_yes_no_answer(
+                    "Generate MIDI for these chords in the NEW key/scale?"
+                ):
+                    trans_chord_names_actual, _, trans_midi_notes_actual, _ = (
                         chord_builder.generate_scale_chords(
-                            new_tonic, new_scale_data,
-                            selected_extension_lvl, selected_inversion_idx
+                            new_tonic,
+                            new_scale_data,
+                            selected_extension_lvl,
+                            selected_inversion_idx,
                         )
+                    )
                     if trans_chord_names_actual:
                         transposed_chords_for_midi: List[Dict[str, Any]] = []
                         for original_prog_item_data in chords_for_midi_processing:
                             original_degree = original_prog_item_data["grado"]
-                            original_duration = original_prog_item_data["duracion_beats"]
+                            original_duration = original_prog_item_data[
+                                "duracion_beats"
+                            ]
                             if original_degree in trans_chord_names_actual:
-                                transposed_chords_for_midi.append({
-                                    "grado": original_degree,
-                                    "nombre": trans_chord_names_actual[original_degree],
-                                    "notas_midi": trans_midi_notes_actual[original_degree],
-                                    "duracion_beats": original_duration
-                                })
+                                transposed_chords_for_midi.append(
+                                    {
+                                        "grado": original_degree,
+                                        "nombre": trans_chord_names_actual[
+                                            original_degree
+                                        ],
+                                        "notas_midi": trans_midi_notes_actual[
+                                            original_degree
+                                        ],
+                                        "duracion_beats": original_duration,
+                                    }
+                                )
                         if transposed_chords_for_midi:
-                            sugg_trans_path = _generate_midi_filename_helper(new_tonic, new_scale_data, midi_export_default_dir, prefix="prog_TRANSP_")
-                            trans_midi_fname_out = safe_input(f"{Fore.CYAN}Enter transposed MIDI filename [default: {sugg_trans_path}]: {Style.RESET_ALL}").strip()
+                            sugg_trans_path = _generate_midi_filename_helper(
+                                new_tonic,
+                                new_scale_data,
+                                midi_export_default_dir,
+                                prefix="prog_TRANSP_",
+                            )
+                            trans_midi_fname_out = safe_input(
+                                f"{Fore.CYAN}Enter transposed MIDI filename "
+                                f"[default: {sugg_trans_path}]: {Style.RESET_ALL}"
+                            ).strip()
                             if not trans_midi_fname_out:
                                 trans_midi_fname_out = sugg_trans_path
                             else:
-                                trans_midi_fname_out = os.path.join(midi_export_default_dir, os.path.basename(trans_midi_fname_out))
-                            midi_builder.generate_midi_file(transposed_chords_for_midi, trans_midi_fname_out, advanced_midi_opts)
+                                trans_midi_fname_out = os.path.join(
+                                    midi_export_default_dir,
+                                    os.path.basename(trans_midi_fname_out),
+                                )
+                            midi_builder.generate_midi_file(
+                                transposed_chords_for_midi,
+                                trans_midi_fname_out,
+                                advanced_midi_opts,
+                            )
 
     return get_yes_no_answer("Perform another operation?")
 
@@ -214,7 +288,7 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
 def main():
     # Initialize colorama for cross-platform color support
     colorama.init()
-    
+
     theory = MusicTheory()
     ui = UIManager(theory)
     chord_builder = ChordGenerator(theory)
@@ -223,16 +297,24 @@ def main():
 
     print_welcome_message()
     home_directory = os.path.expanduser("~")
-    midi_export_default_dir = os.path.join(home_directory, "chord_generator_midi_exports")
+    midi_export_default_dir = os.path.join(
+        home_directory, "chord_generator_midi_exports"
+    )
 
     while True:
-        if not process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export_default_dir):
-            print(f"{Fore.GREEN}Thank you for using the Advanced Chord Generator. Goodbye!{Style.RESET_ALL}")
+        if not process_single_run(
+            ui, chord_builder, tab_builder, midi_builder, midi_export_default_dir
+        ):
+            print(
+                f"{Fore.GREEN}Thank you for using the Advanced Chord Generator. Goodbye!"
+                f"{Style.RESET_ALL}"
+            )
             break
 
 
 if __name__ == "__main__":
     import sys
+
     try:
         main()
     except (EOFError, KeyboardInterrupt):

--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -13,7 +13,8 @@ from .ui import (
     get_yes_no_answer,
     get_numbered_option, 
     get_chord_settings,
-    get_tablature_filter
+    get_tablature_filter,
+    safe_input
 )
 from .generators import ChordGenerator, TablatureGenerator, MidiGenerator
 
@@ -117,9 +118,9 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
     chords_for_midi_processing: List[Dict[str, Any]] = []
     if get_yes_no_answer(
             "Define a chord progression for MIDI? (If no, all diatonic chords will be used sequentially)"):
-        progression_input_str = input(
-            "Enter progression (degrees separated by '-', e.g., I-V-vi-IV). "
-            "Optional duration in beats (e.g., I:4-V:2-vi:2-IV:4 ): "
+        progression_input_str = safe_input(
+            f"{Fore.CYAN}Enter progression (degrees separated by '-', e.g., I-V-vi-IV). "
+            f"Optional duration in beats (e.g., I:4-V:2-vi:2-IV:4 ): {Style.RESET_ALL}"
         ).strip().upper()
         progression_items = progression_input_str.split('-')
         for item_str in progression_items:
@@ -162,7 +163,7 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
     advanced_midi_opts = ui.get_advanced_midi_options()
     suggested_midi_path = _generate_midi_filename_helper(selected_scale_tonic, selected_scale_info, midi_export_default_dir)
 
-    output_midi_filename = input(f"Enter MIDI filename [default: {suggested_midi_path}]: ").strip()
+    output_midi_filename = safe_input(f"{Fore.CYAN}Enter MIDI filename [default: {suggested_midi_path}]: {Style.RESET_ALL}").strip()
     if not output_midi_filename:
         output_midi_filename = suggested_midi_path
     else:
@@ -200,7 +201,7 @@ def process_single_run(ui, chord_builder, tab_builder, midi_builder, midi_export
                                 })
                         if transposed_chords_for_midi:
                             sugg_trans_path = _generate_midi_filename_helper(new_tonic, new_scale_data, midi_export_default_dir, prefix="prog_TRANSP_")
-                            trans_midi_fname_out = input(f"Enter transposed MIDI filename [default: {sugg_trans_path}]: ").strip()
+                            trans_midi_fname_out = safe_input(f"{Fore.CYAN}Enter transposed MIDI filename [default: {sugg_trans_path}]: {Style.RESET_ALL}").strip()
                             if not trans_midi_fname_out:
                                 trans_midi_fname_out = sugg_trans_path
                             else:

--- a/src/chorderizer/generators.py
+++ b/src/chorderizer/generators.py
@@ -125,7 +125,8 @@ class ChordGenerator:
             )
             if not chord_intervals_relative:  # Fallback if type is unknown
                 print(
-                    f"\033[33mWarning: Chord structure for '{chord_type_to_use}' or '{base_quality}' not found. Skipping chord for degree {degree_roman}.\033[0m"
+                    f"\033[33mWarning: Chord structure for '{chord_type_to_use}' or '{base_quality}' "
+                    f"not found. Skipping chord for degree {degree_roman}.\033[0m"
                 )
                 continue
 
@@ -315,7 +316,6 @@ class TablatureGenerator:
         return tab_lines
 
 
-
 # -----------------------------------------------------------------------------
 # Class VoiceLeader
 # -----------------------------------------------------------------------------
@@ -330,8 +330,9 @@ class VoiceLeader:
     MIDI range is clamped to [MIDI_MIN, MIDI_MAX] (C2 - C7) to keep
     voicings in a playable, musical register.
     """
-    MIDI_MIN: int = 36   # C2
-    MIDI_MAX: int = 96   # C7
+
+    MIDI_MIN: int = 36  # C2
+    MIDI_MAX: int = 96  # C7
 
     @staticmethod
     def apply(prev_notes: List[int], curr_notes: List[int]) -> List[int]:
@@ -369,7 +370,9 @@ class VoiceLeader:
             candidates = [
                 pitch_class + (octave * 12)
                 for octave in range(1, 9)
-                if max(VoiceLeader.MIDI_MIN, bass_note) <= pitch_class + (octave * 12) <= VoiceLeader.MIDI_MAX
+                if max(VoiceLeader.MIDI_MIN, bass_note)
+                <= pitch_class + (octave * 12)
+                <= VoiceLeader.MIDI_MAX
             ]
 
             if not candidates:
@@ -387,7 +390,9 @@ class VoiceLeader:
             if i < len(prev_notes):
                 best = min(candidates, key=lambda c: abs(c - prev_notes[i]))
             else:
-                best = min(candidates, key=lambda c: min(abs(c - p) for p in prev_notes))
+                best = min(
+                    candidates, key=lambda c: min(abs(c - p) for p in prev_notes)
+                )
             result.append(best)
 
         # Ensure the result is sorted ascending (good practice for MIDI block chords)
@@ -432,7 +437,9 @@ class MidiGenerator:
             )
         )
         chord_track.append(
-            MetaMessage("set_tempo", tempo=bpm2tempo(midi_options.get("bpm", 120)), time=0)
+            MetaMessage(
+                "set_tempo", tempo=bpm2tempo(midi_options.get("bpm", 120)), time=0
+            )
         )
 
         # Bass Track (optional)
@@ -451,7 +458,9 @@ class MidiGenerator:
             )
             # Bass track also needs tempo if it's the first event-producing track for it
             bass_track.append(
-                MetaMessage("set_tempo", tempo=bpm2tempo(midi_options.get("bpm", 120)), time=0)
+                MetaMessage(
+                    "set_tempo", tempo=bpm2tempo(midi_options.get("bpm", 120)), time=0
+                )
             )
 
         # Pre-calculate arpeggio individual note duration since it is constant across chords
@@ -490,7 +499,9 @@ class MidiGenerator:
                     bass_note_midi += 12
 
                 # Slightly higher velocity for bass, or make it configurable
-                bass_velocity = max(0, min(127, midi_options.get("base_velocity", 70) + 10))
+                bass_velocity = max(
+                    0, min(127, midi_options.get("base_velocity", 70) + 10)
+                )
 
                 # Ensure bass note is within valid MIDI range [0, 127]
                 bass_note_midi = max(0, min(127, bass_note_midi))

--- a/src/chorderizer/theory_utils.py
+++ b/src/chorderizer/theory_utils.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Tuple, Optional, Any
 
+
 # -----------------------------------------------------------------------------
 # Class MusicTheoryUtils: Utility functions for music theory
 # -----------------------------------------------------------------------------
@@ -7,7 +8,20 @@ class MusicTheoryUtils:
     @staticmethod
     def get_note_name(note_index: int, use_flats: bool = False) -> str:
         if use_flats:
-            flat_names = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"]
+            flat_names = [
+                "C",
+                "Db",
+                "D",
+                "Eb",
+                "E",
+                "F",
+                "Gb",
+                "G",
+                "Ab",
+                "A",
+                "Bb",
+                "B",
+            ]
             return flat_names[note_index % 12]
         return MusicTheory.CHROMATIC_NOTES[note_index % 12]
 
@@ -17,7 +31,7 @@ class MusicTheoryUtils:
         tonic_upper = tonic_str.upper()
         # Explicit flat in name ('b') or known flat keys (F is the classic one)
         # We check for 'b' in lowercase string.
-        if 'b' in tonic_str.lower():
+        if "b" in tonic_str.lower():
             return True
         # Check start of the string for keys that use flats but don't have 'b' in name (F Major)
         for flat_key in ["F", "BB", "EB", "AB", "DB", "GB"]:
@@ -36,15 +50,22 @@ class MusicTheoryUtils:
         if base_note in MusicTheoryUtils._NOTE_INDEX_CACHE:
             return MusicTheoryUtils._NOTE_INDEX_CACHE[base_note]
 
-        flat_to_sharp_equivalents = {"DB": "C#", "EB": "D#", "FB": "E", "GB": "F#", "AB": "G#", "BB": "A#",
-                                     "CB": "B"}
+        flat_to_sharp_equivalents = {
+            "DB": "C#",
+            "EB": "D#",
+            "FB": "E",
+            "GB": "F#",
+            "AB": "G#",
+            "BB": "A#",
+            "CB": "B",
+        }
         for flat, sharp in flat_to_sharp_equivalents.items():
             if base_note.startswith(flat):
-                base_note = sharp + base_note[len(flat):]
+                base_note = sharp + base_note[len(flat) :]
                 break
         root_note_str = ""
         for char_note in base_note:
-            if char_note.isalpha() or char_note == '#':
+            if char_note.isalpha() or char_note == "#":
                 root_note_str += char_note
             else:
                 break
@@ -54,28 +75,34 @@ class MusicTheoryUtils:
             MusicTheoryUtils._NOTE_INDEX_CACHE[note_name.upper()] = res
             return res
         except ValueError:
-            raise ValueError(f"Base note '{root_note_str}' from '{note_name}' not recognized.")
+            raise ValueError(
+                f"Base note '{root_note_str}' from '{note_name}' not recognized."
+            )
 
     @staticmethod
     def split_chord_name(chord_name: str) -> Tuple[str, str]:
         """Splits a chord name into its root and its suffix (e.g., 'C#maj7' -> ('C#', 'maj7'))."""
         if not chord_name:
             return "", ""
-        
+
         # Check for two-character roots (C#, Bb, etc.)
-        if len(chord_name) > 1 and chord_name[1] in ['#', 'b', 'B']:
+        if len(chord_name) > 1 and chord_name[1] in ["#", "b", "B"]:
             return chord_name[:2], chord_name[2:]
-        
+
         # Default to one-character root
         return chord_name[:1], chord_name[1:]
 
     @staticmethod
-    def transpose_chords(original_chords_dict: Dict[str, str],
-                         original_scale_tonic_str: str,
-                         new_scale_tonic_str: str) -> Optional[Dict[str, str]]:
+    def transpose_chords(
+        original_chords_dict: Dict[str, str],
+        original_scale_tonic_str: str,
+        new_scale_tonic_str: str,
+    ) -> Optional[Dict[str, str]]:
         """Transposes a dictionary of chords to a new scale tonic."""
         try:
-            original_tonic_idx = MusicTheoryUtils.get_note_index(original_scale_tonic_str)
+            original_tonic_idx = MusicTheoryUtils.get_note_index(
+                original_scale_tonic_str
+            )
             new_tonic_idx = MusicTheoryUtils.get_note_index(new_scale_tonic_str)
         except ValueError as e:
             print(f"\033[31mError parsing tonic for transposition: {e}\033[0m")
@@ -86,7 +113,7 @@ class MusicTheoryUtils:
 
         for degree, original_chord_name in original_chords_dict.items():
             root_str, suffix = MusicTheoryUtils.split_chord_name(original_chord_name)
-            
+
             try:
                 original_root_idx = MusicTheoryUtils.get_note_index(root_str)
             except ValueError:
@@ -97,10 +124,10 @@ class MusicTheoryUtils:
             new_root_idx = (original_root_idx + transposition_interval) % 12
             # Determine whether to use flats based on the new tonic
             use_flats = MusicTheoryUtils.should_use_flats(new_scale_tonic_str)
-            
+
             new_root_name = MusicTheoryUtils.get_note_name(new_root_idx, use_flats)
             transposed_chords_dict[degree] = new_root_name + suffix
-            
+
         return transposed_chords_dict
 
 
@@ -108,15 +135,47 @@ class MusicTheoryUtils:
 # Class MusicTheory: Constants and basic music theory definitions
 # -----------------------------------------------------------------------------
 class MusicTheory:
-    CHROMATIC_NOTES: List[str] = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+    CHROMATIC_NOTES: List[str] = [
+        "C",
+        "C#",
+        "D",
+        "D#",
+        "E",
+        "F",
+        "F#",
+        "G",
+        "G#",
+        "A",
+        "A#",
+        "B",
+    ]
     MIDI_BASE_OCTAVE: int = 60  # C4
 
     INTERVALS: Dict[str, int] = {
-        "R": 0, "m2": 1, "M2": 2, "m3": 3, "M3": 4, "P4": 5, "A4": 6, "TRITONE": 6, "d5": 6, "P5": 7, "A5": 8,
-        "m6": 8, "M6": 9, "d7": 9, "m7": 10, "M7": 11, "P8": 12,
-        "m9": 13, "M9": 14, "A9": 15,
-        "P11": 17, "A11": 18,
-        "m13": 20, "M13": 21
+        "R": 0,
+        "m2": 1,
+        "M2": 2,
+        "m3": 3,
+        "M3": 4,
+        "P4": 5,
+        "A4": 6,
+        "TRITONE": 6,
+        "d5": 6,
+        "P5": 7,
+        "A5": 8,
+        "m6": 8,
+        "M6": 9,
+        "d7": 9,
+        "m7": 10,
+        "M7": 11,
+        "P8": 12,
+        "m9": 13,
+        "M9": 14,
+        "A9": 15,
+        "P11": 17,
+        "A11": 18,
+        "m13": 20,
+        "M13": 21,
     }
 
     CHORD_STRUCTURES: Dict[str, List[int]] = {
@@ -133,27 +192,104 @@ class MusicTheory:
         "min7": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["P5"], INTERVALS["m7"]],
         "minMaj7": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["P5"], INTERVALS["M7"]],
         "dim7": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["d5"], INTERVALS["d7"]],
-        "halfdim7": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["d5"], INTERVALS["m7"]],  # m7b5
+        "halfdim7": [
+            INTERVALS["R"],
+            INTERVALS["m3"],
+            INTERVALS["d5"],
+            INTERVALS["m7"],
+        ],  # m7b5
         "aug7": [INTERVALS["R"], INTERVALS["M3"], INTERVALS["A5"], INTERVALS["m7"]],
         "augMaj7": [INTERVALS["R"], INTERVALS["M3"], INTERVALS["A5"], INTERVALS["M7"]],
-        "dom9": [INTERVALS["R"], INTERVALS["M3"], INTERVALS["P5"], INTERVALS["m7"], INTERVALS["M9"]],
-        "maj9": [INTERVALS["R"], INTERVALS["M3"], INTERVALS["P5"], INTERVALS["M7"], INTERVALS["M9"]],
-        "min9": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["P5"], INTERVALS["m7"], INTERVALS["M9"]],
-        "minMaj9": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["P5"], INTERVALS["M7"], INTERVALS["M9"]],
-        "halfdim9": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["d5"], INTERVALS["m7"], INTERVALS["m9"]],
-        "dimM9": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["d5"], INTERVALS["d7"], INTERVALS["M9"]],
-        "dom11": [INTERVALS["R"], INTERVALS["M3"], INTERVALS["P5"], INTERVALS["m7"], INTERVALS["M9"],
-                  INTERVALS["P11"]],
-        "maj11": [INTERVALS["R"], INTERVALS["M3"], INTERVALS["P5"], INTERVALS["M7"], INTERVALS["M9"],
-                  INTERVALS["P11"]],
-        "min11": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["P5"], INTERVALS["m7"], INTERVALS["M9"],
-                  INTERVALS["P11"]],
-        "dom13": [INTERVALS["R"], INTERVALS["M3"], INTERVALS["P5"], INTERVALS["m7"], INTERVALS["M9"],
-                  INTERVALS["M13"]],
-        "maj13": [INTERVALS["R"], INTERVALS["M3"], INTERVALS["P5"], INTERVALS["M7"], INTERVALS["M9"],
-                  INTERVALS["M13"]],
-        "min13": [INTERVALS["R"], INTERVALS["m3"], INTERVALS["P5"], INTERVALS["m7"], INTERVALS["M9"],
-                  INTERVALS["M13"]],
+        "dom9": [
+            INTERVALS["R"],
+            INTERVALS["M3"],
+            INTERVALS["P5"],
+            INTERVALS["m7"],
+            INTERVALS["M9"],
+        ],
+        "maj9": [
+            INTERVALS["R"],
+            INTERVALS["M3"],
+            INTERVALS["P5"],
+            INTERVALS["M7"],
+            INTERVALS["M9"],
+        ],
+        "min9": [
+            INTERVALS["R"],
+            INTERVALS["m3"],
+            INTERVALS["P5"],
+            INTERVALS["m7"],
+            INTERVALS["M9"],
+        ],
+        "minMaj9": [
+            INTERVALS["R"],
+            INTERVALS["m3"],
+            INTERVALS["P5"],
+            INTERVALS["M7"],
+            INTERVALS["M9"],
+        ],
+        "halfdim9": [
+            INTERVALS["R"],
+            INTERVALS["m3"],
+            INTERVALS["d5"],
+            INTERVALS["m7"],
+            INTERVALS["m9"],
+        ],
+        "dimM9": [
+            INTERVALS["R"],
+            INTERVALS["m3"],
+            INTERVALS["d5"],
+            INTERVALS["d7"],
+            INTERVALS["M9"],
+        ],
+        "dom11": [
+            INTERVALS["R"],
+            INTERVALS["M3"],
+            INTERVALS["P5"],
+            INTERVALS["m7"],
+            INTERVALS["M9"],
+            INTERVALS["P11"],
+        ],
+        "maj11": [
+            INTERVALS["R"],
+            INTERVALS["M3"],
+            INTERVALS["P5"],
+            INTERVALS["M7"],
+            INTERVALS["M9"],
+            INTERVALS["P11"],
+        ],
+        "min11": [
+            INTERVALS["R"],
+            INTERVALS["m3"],
+            INTERVALS["P5"],
+            INTERVALS["m7"],
+            INTERVALS["M9"],
+            INTERVALS["P11"],
+        ],
+        "dom13": [
+            INTERVALS["R"],
+            INTERVALS["M3"],
+            INTERVALS["P5"],
+            INTERVALS["m7"],
+            INTERVALS["M9"],
+            INTERVALS["M13"],
+        ],
+        "maj13": [
+            INTERVALS["R"],
+            INTERVALS["M3"],
+            INTERVALS["P5"],
+            INTERVALS["M7"],
+            INTERVALS["M9"],
+            INTERVALS["M13"],
+        ],
+        "min13": [
+            INTERVALS["R"],
+            INTERVALS["m3"],
+            INTERVALS["P5"],
+            INTERVALS["m7"],
+            INTERVALS["M9"],
+            INTERVALS["M13"],
+        ],
     }
 
     # Scale Definitions
@@ -166,86 +302,328 @@ class MusicTheory:
 
     # Diatonic Chords for Scales
     MAJOR_SCALE_DEGREES: Dict[str, Dict[str, Any]] = {
-        "I": {"root_interval": 0, "base_quality": "major", "full_quality": "maj7", "display_suffix": "maj7"},
-        "ii": {"root_interval": 2, "base_quality": "minor", "full_quality": "min7", "display_suffix": "m7"},
-        "iii": {"root_interval": 4, "base_quality": "minor", "full_quality": "min7", "display_suffix": "m7"},
-        "IV": {"root_interval": 5, "base_quality": "major", "full_quality": "maj7", "display_suffix": "maj7"},
-        "V": {"root_interval": 7, "base_quality": "major", "full_quality": "dom7", "display_suffix": "7"},
-        "vi": {"root_interval": 9, "base_quality": "minor", "full_quality": "min7", "display_suffix": "m7"},
-        "vii°": {"root_interval": 11, "base_quality": "diminished", "full_quality": "halfdim7",
-                 "display_suffix": "m7b5"}
+        "I": {
+            "root_interval": 0,
+            "base_quality": "major",
+            "full_quality": "maj7",
+            "display_suffix": "maj7",
+        },
+        "ii": {
+            "root_interval": 2,
+            "base_quality": "minor",
+            "full_quality": "min7",
+            "display_suffix": "m7",
+        },
+        "iii": {
+            "root_interval": 4,
+            "base_quality": "minor",
+            "full_quality": "min7",
+            "display_suffix": "m7",
+        },
+        "IV": {
+            "root_interval": 5,
+            "base_quality": "major",
+            "full_quality": "maj7",
+            "display_suffix": "maj7",
+        },
+        "V": {
+            "root_interval": 7,
+            "base_quality": "major",
+            "full_quality": "dom7",
+            "display_suffix": "7",
+        },
+        "vi": {
+            "root_interval": 9,
+            "base_quality": "minor",
+            "full_quality": "min7",
+            "display_suffix": "m7",
+        },
+        "vii°": {
+            "root_interval": 11,
+            "base_quality": "diminished",
+            "full_quality": "halfdim7",
+            "display_suffix": "m7b5",
+        },
     }
     NATURAL_MINOR_SCALE_DEGREES: Dict[str, Dict[str, Any]] = {
-        "i": {"root_interval": 0, "base_quality": "minor", "full_quality": "min7", "display_suffix": "m7"},
-        "ii°": {"root_interval": 2, "base_quality": "diminished", "full_quality": "halfdim7",
-                "display_suffix": "m7b5"},
-        "III": {"root_interval": 3, "base_quality": "major", "full_quality": "maj7", "display_suffix": "maj7"},
-        "iv": {"root_interval": 5, "base_quality": "minor", "full_quality": "min7", "display_suffix": "m7"},
-        "v": {"root_interval": 7, "base_quality": "minor", "full_quality": "min7", "display_suffix": "m7"},
-        "VI": {"root_interval": 8, "base_quality": "major", "full_quality": "maj7", "display_suffix": "maj7"},
-        "VII": {"root_interval": 10, "base_quality": "major", "full_quality": "dom7", "display_suffix": "7"}
+        "i": {
+            "root_interval": 0,
+            "base_quality": "minor",
+            "full_quality": "min7",
+            "display_suffix": "m7",
+        },
+        "ii°": {
+            "root_interval": 2,
+            "base_quality": "diminished",
+            "full_quality": "halfdim7",
+            "display_suffix": "m7b5",
+        },
+        "III": {
+            "root_interval": 3,
+            "base_quality": "major",
+            "full_quality": "maj7",
+            "display_suffix": "maj7",
+        },
+        "iv": {
+            "root_interval": 5,
+            "base_quality": "minor",
+            "full_quality": "min7",
+            "display_suffix": "m7",
+        },
+        "v": {
+            "root_interval": 7,
+            "base_quality": "minor",
+            "full_quality": "min7",
+            "display_suffix": "m7",
+        },
+        "VI": {
+            "root_interval": 8,
+            "base_quality": "major",
+            "full_quality": "maj7",
+            "display_suffix": "maj7",
+        },
+        "VII": {
+            "root_interval": 10,
+            "base_quality": "major",
+            "full_quality": "dom7",
+            "display_suffix": "7",
+        },
     }
     HARMONIC_MINOR_SCALE_DEGREES: Dict[str, Dict[str, Any]] = {
-        "i": {"root_interval": 0, "base_quality": "minor", "full_quality": "minMaj7", "display_suffix": "m(maj7)"},
-        "ii°": {"root_interval": 2, "base_quality": "diminished", "full_quality": "halfdim7",
-                "display_suffix": "m7b5"},
-        "III+": {"root_interval": 3, "base_quality": "augmented", "full_quality": "augMaj7",
-                 "display_suffix": "aug(maj7)"},
-        "iv": {"root_interval": 5, "base_quality": "minor", "full_quality": "min7", "display_suffix": "m7"},
-        "V": {"root_interval": 7, "base_quality": "major", "full_quality": "dom7", "display_suffix": "7"},
-        "VI": {"root_interval": 8, "base_quality": "major", "full_quality": "maj7", "display_suffix": "maj7"},
-        "vii°7": {"root_interval": 11, "base_quality": "diminished", "full_quality": "dim7", "display_suffix": "dim7"}
+        "i": {
+            "root_interval": 0,
+            "base_quality": "minor",
+            "full_quality": "minMaj7",
+            "display_suffix": "m(maj7)",
+        },
+        "ii°": {
+            "root_interval": 2,
+            "base_quality": "diminished",
+            "full_quality": "halfdim7",
+            "display_suffix": "m7b5",
+        },
+        "III+": {
+            "root_interval": 3,
+            "base_quality": "augmented",
+            "full_quality": "augMaj7",
+            "display_suffix": "aug(maj7)",
+        },
+        "iv": {
+            "root_interval": 5,
+            "base_quality": "minor",
+            "full_quality": "min7",
+            "display_suffix": "m7",
+        },
+        "V": {
+            "root_interval": 7,
+            "base_quality": "major",
+            "full_quality": "dom7",
+            "display_suffix": "7",
+        },
+        "VI": {
+            "root_interval": 8,
+            "base_quality": "major",
+            "full_quality": "maj7",
+            "display_suffix": "maj7",
+        },
+        "vii°7": {
+            "root_interval": 11,
+            "base_quality": "diminished",
+            "full_quality": "dim7",
+            "display_suffix": "dim7",
+        },
     }
     MELODIC_MINOR_ASC_SCALE_DEGREES: Dict[str, Dict[str, Any]] = {
-        "i": {"root_interval": 0, "base_quality": "minor", "full_quality": "minMaj7", "display_suffix": "m(maj7)"},
-        "ii": {"root_interval": 2, "base_quality": "minor", "full_quality": "min7", "display_suffix": "m7"},
-        "III+": {"root_interval": 3, "base_quality": "augmented", "full_quality": "augMaj7",
-                 "display_suffix": "aug(maj7)"},
-        "IV": {"root_interval": 5, "base_quality": "major", "full_quality": "dom7", "display_suffix": "7"},
-        "V": {"root_interval": 7, "base_quality": "major", "full_quality": "dom7", "display_suffix": "7"},
-        "vi°": {"root_interval": 9, "base_quality": "diminished", "full_quality": "halfdim7",
-                "display_suffix": "m7b5"},
-        "vii°": {"root_interval": 11, "base_quality": "diminished", "full_quality": "halfdim7",
-                 "display_suffix": "m7b5"}
+        "i": {
+            "root_interval": 0,
+            "base_quality": "minor",
+            "full_quality": "minMaj7",
+            "display_suffix": "m(maj7)",
+        },
+        "ii": {
+            "root_interval": 2,
+            "base_quality": "minor",
+            "full_quality": "min7",
+            "display_suffix": "m7",
+        },
+        "III+": {
+            "root_interval": 3,
+            "base_quality": "augmented",
+            "full_quality": "augMaj7",
+            "display_suffix": "aug(maj7)",
+        },
+        "IV": {
+            "root_interval": 5,
+            "base_quality": "major",
+            "full_quality": "dom7",
+            "display_suffix": "7",
+        },
+        "V": {
+            "root_interval": 7,
+            "base_quality": "major",
+            "full_quality": "dom7",
+            "display_suffix": "7",
+        },
+        "vi°": {
+            "root_interval": 9,
+            "base_quality": "diminished",
+            "full_quality": "halfdim7",
+            "display_suffix": "m7b5",
+        },
+        "vii°": {
+            "root_interval": 11,
+            "base_quality": "diminished",
+            "full_quality": "halfdim7",
+            "display_suffix": "m7b5",
+        },
     }
     MAJOR_PENTATONIC_SCALE_DEGREES: Dict[str, Dict[str, Any]] = {
-        "I": {"root_interval": 0, "base_quality": "major", "full_quality": "major", "display_suffix": ""},
-        "ii_p": {"root_interval": 2, "base_quality": "minor", "full_quality": "minor", "display_suffix": "m"},
-        "iii_p": {"root_interval": 4, "base_quality": "minor", "full_quality": "minor", "display_suffix": "m"},
-        "V_p": {"root_interval": 7, "base_quality": "major", "full_quality": "major", "display_suffix": ""},
-        "vi_p": {"root_interval": 9, "base_quality": "minor", "full_quality": "minor", "display_suffix": "m"}
+        "I": {
+            "root_interval": 0,
+            "base_quality": "major",
+            "full_quality": "major",
+            "display_suffix": "",
+        },
+        "ii_p": {
+            "root_interval": 2,
+            "base_quality": "minor",
+            "full_quality": "minor",
+            "display_suffix": "m",
+        },
+        "iii_p": {
+            "root_interval": 4,
+            "base_quality": "minor",
+            "full_quality": "minor",
+            "display_suffix": "m",
+        },
+        "V_p": {
+            "root_interval": 7,
+            "base_quality": "major",
+            "full_quality": "major",
+            "display_suffix": "",
+        },
+        "vi_p": {
+            "root_interval": 9,
+            "base_quality": "minor",
+            "full_quality": "minor",
+            "display_suffix": "m",
+        },
     }
     MINOR_PENTATONIC_SCALE_DEGREES: Dict[str, Dict[str, Any]] = {
-        "i_p": {"root_interval": 0, "base_quality": "minor", "full_quality": "minor", "display_suffix": "m"},
-        "III_p": {"root_interval": 3, "base_quality": "major", "full_quality": "major", "display_suffix": ""},
-        "iv_p": {"root_interval": 5, "base_quality": "minor", "full_quality": "minor", "display_suffix": "m"},
-        "v_p": {"root_interval": 7, "base_quality": "minor", "full_quality": "minor", "display_suffix": "m"},
-        "VII_p": {"root_interval": 10, "base_quality": "major", "full_quality": "major", "display_suffix": ""}
+        "i_p": {
+            "root_interval": 0,
+            "base_quality": "minor",
+            "full_quality": "minor",
+            "display_suffix": "m",
+        },
+        "III_p": {
+            "root_interval": 3,
+            "base_quality": "major",
+            "full_quality": "major",
+            "display_suffix": "",
+        },
+        "iv_p": {
+            "root_interval": 5,
+            "base_quality": "minor",
+            "full_quality": "minor",
+            "display_suffix": "m",
+        },
+        "v_p": {
+            "root_interval": 7,
+            "base_quality": "minor",
+            "full_quality": "minor",
+            "display_suffix": "m",
+        },
+        "VII_p": {
+            "root_interval": 10,
+            "base_quality": "major",
+            "full_quality": "major",
+            "display_suffix": "",
+        },
     }
 
     AVAILABLE_SCALES: Dict[str, Dict[str, Any]] = {
         "1": {"name": SCALE_MAJOR, "degrees": MAJOR_SCALE_DEGREES, "tonic_suffix": ""},
-        "2": {"name": SCALE_NATURAL_MINOR, "degrees": NATURAL_MINOR_SCALE_DEGREES, "tonic_suffix": "m"},
-        "3": {"name": SCALE_HARMONIC_MINOR, "degrees": HARMONIC_MINOR_SCALE_DEGREES, "tonic_suffix": "m"},
-        "4": {"name": SCALE_MELODIC_MINOR_ASC, "degrees": MELODIC_MINOR_ASC_SCALE_DEGREES, "tonic_suffix": "m"},
-        "5": {"name": SCALE_MAJOR_PENTATONIC, "degrees": MAJOR_PENTATONIC_SCALE_DEGREES, "tonic_suffix": ""},
-        "6": {"name": SCALE_MINOR_PENTATONIC, "degrees": MINOR_PENTATONIC_SCALE_DEGREES, "tonic_suffix": "m"},
+        "2": {
+            "name": SCALE_NATURAL_MINOR,
+            "degrees": NATURAL_MINOR_SCALE_DEGREES,
+            "tonic_suffix": "m",
+        },
+        "3": {
+            "name": SCALE_HARMONIC_MINOR,
+            "degrees": HARMONIC_MINOR_SCALE_DEGREES,
+            "tonic_suffix": "m",
+        },
+        "4": {
+            "name": SCALE_MELODIC_MINOR_ASC,
+            "degrees": MELODIC_MINOR_ASC_SCALE_DEGREES,
+            "tonic_suffix": "m",
+        },
+        "5": {
+            "name": SCALE_MAJOR_PENTATONIC,
+            "degrees": MAJOR_PENTATONIC_SCALE_DEGREES,
+            "tonic_suffix": "",
+        },
+        "6": {
+            "name": SCALE_MINOR_PENTATONIC,
+            "degrees": MINOR_PENTATONIC_SCALE_DEGREES,
+            "tonic_suffix": "m",
+        },
     }
 
     MIDI_PROGRAMS: Dict[int, str] = {
-        0: "Acoustic Grand Piano", 1: "Bright Acoustic Piano", 2: "Electric Grand Piano", 3: "Honky-tonk Piano",
-        4: "Electric Piano 1 (Rhodes)", 5: "Electric Piano 2 (Chorused)", 6: "Harpsichord", 7: "Clavinet",
-        8: "Celesta", 9: "Glockenspiel", 10: "Music Box", 11: "Vibraphone", 12: "Marimba", 13: "Xylophone",
-        16: "Drawbar Organ", 17: "Percussive Organ", 19: "Church Organ",
-        24: "Acoustic Guitar (nylon)", 25: "Acoustic Guitar (steel)", 26: "Electric Guitar (jazz)",
+        0: "Acoustic Grand Piano",
+        1: "Bright Acoustic Piano",
+        2: "Electric Grand Piano",
+        3: "Honky-tonk Piano",
+        4: "Electric Piano 1 (Rhodes)",
+        5: "Electric Piano 2 (Chorused)",
+        6: "Harpsichord",
+        7: "Clavinet",
+        8: "Celesta",
+        9: "Glockenspiel",
+        10: "Music Box",
+        11: "Vibraphone",
+        12: "Marimba",
+        13: "Xylophone",
+        16: "Drawbar Organ",
+        17: "Percussive Organ",
+        19: "Church Organ",
+        24: "Acoustic Guitar (nylon)",
+        25: "Acoustic Guitar (steel)",
+        26: "Electric Guitar (jazz)",
         27: "Electric Guitar (clean)",
-        28: "Electric Guitar (muted)", 29: "Overdriven Guitar", 30: "Distortion Guitar",
-        32: "Acoustic Bass", 33: "Electric Bass (finger)", 34: "Electric Bass (pick)", 35: "Fretless Bass",
-        36: "Slap Bass 1", 37: "Slap Bass 2", 38: "Synth Bass 1", 39: "Synth Bass 2",
-        40: "Violin", 41: "Viola", 42: "Cello", 43: "Contrabass", 48: "String Ensemble 1", 49: "String Ensemble 2",
-        52: "Choir Aahs", 53: "Voice Oohs", 54: "Synth Voice", 56: "Trumpet", 57: "Trombone", 60: "French Horn",
-        64: "Soprano Sax", 65: "Alto Sax", 66: "Tenor Sax", 67: "Baritone Sax", 71: "Clarinet", 73: "Flute",
-        80: "Synth Lead 1 (square)", 81: "Synth Lead 2 (sawtooth)", 88: "Synth Pad 1 (new age)",
-        90: "Synth Pad 3 (polysynth)"
+        28: "Electric Guitar (muted)",
+        29: "Overdriven Guitar",
+        30: "Distortion Guitar",
+        32: "Acoustic Bass",
+        33: "Electric Bass (finger)",
+        34: "Electric Bass (pick)",
+        35: "Fretless Bass",
+        36: "Slap Bass 1",
+        37: "Slap Bass 2",
+        38: "Synth Bass 1",
+        39: "Synth Bass 2",
+        40: "Violin",
+        41: "Viola",
+        42: "Cello",
+        43: "Contrabass",
+        48: "String Ensemble 1",
+        49: "String Ensemble 2",
+        52: "Choir Aahs",
+        53: "Voice Oohs",
+        54: "Synth Voice",
+        56: "Trumpet",
+        57: "Trombone",
+        60: "French Horn",
+        64: "Soprano Sax",
+        65: "Alto Sax",
+        66: "Tenor Sax",
+        67: "Baritone Sax",
+        71: "Clarinet",
+        73: "Flute",
+        80: "Synth Lead 1 (square)",
+        81: "Synth Lead 2 (sawtooth)",
+        88: "Synth Pad 1 (new age)",
+        90: "Synth Pad 3 (polysynth)",
     }
-

--- a/src/chorderizer/ui.py
+++ b/src/chorderizer/ui.py
@@ -17,11 +17,19 @@ def print_operation_cancelled() -> None:
     print(f"\n{Fore.RED}Operation cancelled by the user.{Style.RESET_ALL}")
 
 
+def safe_input(prompt: str) -> str:
+    try:
+        return input(prompt)
+    except (EOFError, KeyboardInterrupt):
+        print_operation_cancelled()
+        sys.exit(130)
+
+
 def get_yes_no_answer(prompt: str) -> bool:
     while True:
         try:
             response = (
-                input(f"{Fore.CYAN}{prompt} [y/N]: {Style.RESET_ALL}").strip().lower()
+                safe_input(f"{Fore.CYAN}{prompt} [y/N]: {Style.RESET_ALL}").strip().lower()
             )
             if not response:
                 return False
@@ -34,7 +42,7 @@ def get_yes_no_answer(prompt: str) -> bool:
             )
         except (EOFError, KeyboardInterrupt):
             print_operation_cancelled()
-            sys.exit(0)
+            sys.exit(130)
 
 
 def get_numbered_option(
@@ -57,7 +65,7 @@ def get_numbered_option(
 
     while True:
         try:
-            user_input_str = input("Choose an option number: ").strip()
+            user_input_str = safe_input(f"{Fore.CYAN}Choose an option number: {Style.RESET_ALL}").strip()
             if not user_input_str:
                 continue
 
@@ -170,8 +178,8 @@ class UIManager:
         }
 
         try:
-            bpm_in = input(
-                f"BPM (tempo) for MIDI [default: {options['bpm']}]: "
+            bpm_in = safe_input(
+                f"{Fore.CYAN}BPM (tempo) for MIDI [default: {options['bpm']}]: {Style.RESET_ALL}"
             ).strip()
             if bpm_in:
                 options["bpm"] = int(bpm_in)
@@ -185,8 +193,8 @@ class UIManager:
             print(f"{Fore.RED}Invalid BPM, using {options['bpm']}.{Style.RESET_ALL}")
 
         try:
-            vel_in = input(
-                f"Base note velocity (0-127) [default: {options['base_velocity']}]: "
+            vel_in = safe_input(
+                f"{Fore.CYAN}Base note velocity (0-127) [default: {options['base_velocity']}]: {Style.RESET_ALL}"
             ).strip()
             if vel_in:
                 options["base_velocity"] = int(vel_in)
@@ -198,7 +206,7 @@ class UIManager:
 
         if get_yes_no_answer("Add slight randomization to velocity?"):
             try:
-                rand_in = input(f"Randomization range (+/-) [default: 5]: ").strip()
+                rand_in = safe_input(f"{Fore.CYAN}Randomization range (+/-) [default: 5]: {Style.RESET_ALL}").strip()
                 if rand_in:
                     options["velocity_randomization_range"] = int(rand_in)
                 options["velocity_randomization_range"] = max(
@@ -227,8 +235,8 @@ class UIManager:
             if style_key:
                 options["arpeggio_style"] = arp_styles[style_key]
                 try:
-                    arp_dur_in = input(
-                        f"Duration of each arpeggio note in beats [default: {options['arpeggio_note_duration_beats']}]: "
+                    arp_dur_in = safe_input(
+                        f"{Fore.CYAN}Duration of each arpeggio note in beats [default: {options['arpeggio_note_duration_beats']}]: {Style.RESET_ALL}"
                     ).strip()
                     if arp_dur_in:
                         options["arpeggio_note_duration_beats"] = float(arp_dur_in)
@@ -243,8 +251,8 @@ class UIManager:
             "Add strumming effect to block chords?"
         ):
             try:
-                strum_in = input(
-                    f"Strum delay between notes (milliseconds) [default: 15ms]: "
+                strum_in = safe_input(
+                    f"{Fore.CYAN}Strum delay between notes (milliseconds) [default: 15ms]: {Style.RESET_ALL}"
                 ).strip()
                 if strum_in:
                     options["strum_delay_ms"] = int(strum_in)

--- a/src/chorderizer/ui.py
+++ b/src/chorderizer/ui.py
@@ -1,6 +1,5 @@
 import sys
 from typing import Optional, Tuple, Dict, Any, Union
-import colorama
 from colorama import Fore, Style
 from .theory_utils import MusicTheory
 
@@ -29,7 +28,9 @@ def get_yes_no_answer(prompt: str) -> bool:
     while True:
         try:
             response = (
-                safe_input(f"{Fore.CYAN}{prompt} [y/N]: {Style.RESET_ALL}").strip().lower()
+                safe_input(f"{Fore.CYAN}{prompt} [y/N]: {Style.RESET_ALL}")
+                .strip()
+                .lower()
             )
             if not response:
                 return False
@@ -65,7 +66,9 @@ def get_numbered_option(
 
     while True:
         try:
-            user_input_str = safe_input(f"{Fore.CYAN}Choose an option number: {Style.RESET_ALL}").strip()
+            user_input_str = safe_input(
+                f"{Fore.CYAN}Choose an option number: {Style.RESET_ALL}"
+            ).strip()
             if not user_input_str:
                 continue
 
@@ -179,13 +182,15 @@ class UIManager:
 
         try:
             bpm_in = safe_input(
-                f"{Fore.CYAN}BPM (tempo) for MIDI [default: {options['bpm']}]: {Style.RESET_ALL}"
+                f"{Fore.CYAN}BPM (tempo) for MIDI "
+                f"[default: {options['bpm']}]: {Style.RESET_ALL}"
             ).strip()
             if bpm_in:
                 options["bpm"] = int(bpm_in)
             if not (20 <= options["bpm"] <= 300):  # Reasonable range
                 print(
-                    f"{Fore.YELLOW}Warning: BPM {options['bpm']} is outside the typical range (20-300).{Style.RESET_ALL}"
+                    f"{Fore.YELLOW}Warning: BPM {options['bpm']} is outside "
+                    f"the typical range (20-300).{Style.RESET_ALL}"
                 )
             if options["bpm"] <= 0:
                 options["bpm"] = 120  # Fallback
@@ -194,7 +199,8 @@ class UIManager:
 
         try:
             vel_in = safe_input(
-                f"{Fore.CYAN}Base note velocity (0-127) [default: {options['base_velocity']}]: {Style.RESET_ALL}"
+                f"{Fore.CYAN}Base note velocity (0-127) "
+                f"[default: {options['base_velocity']}]: {Style.RESET_ALL}"
             ).strip()
             if vel_in:
                 options["base_velocity"] = int(vel_in)
@@ -206,7 +212,9 @@ class UIManager:
 
         if get_yes_no_answer("Add slight randomization to velocity?"):
             try:
-                rand_in = safe_input(f"{Fore.CYAN}Randomization range (+/-) [default: 5]: {Style.RESET_ALL}").strip()
+                rand_in = safe_input(
+                    f"{Fore.CYAN}Randomization range (+/-) [default: 5]: {Style.RESET_ALL}"
+                ).strip()
                 if rand_in:
                     options["velocity_randomization_range"] = int(rand_in)
                 options["velocity_randomization_range"] = max(
@@ -236,7 +244,8 @@ class UIManager:
                 options["arpeggio_style"] = arp_styles[style_key]
                 try:
                     arp_dur_in = safe_input(
-                        f"{Fore.CYAN}Duration of each arpeggio note in beats [default: {options['arpeggio_note_duration_beats']}]: {Style.RESET_ALL}"
+                        f"{Fore.CYAN}Duration of each arpeggio note in beats "
+                        f"[default: {options['arpeggio_note_duration_beats']}]: {Style.RESET_ALL}"
                     ).strip()
                     if arp_dur_in:
                         options["arpeggio_note_duration_beats"] = float(arp_dur_in)
@@ -244,7 +253,8 @@ class UIManager:
                         options["arpeggio_note_duration_beats"] = 0.25
                 except ValueError:
                     print(
-                        f"{Fore.RED}Invalid arpeggio note duration, using {options['arpeggio_note_duration_beats']}.{Style.RESET_ALL}"
+                        f"{Fore.RED}Invalid arpeggio note duration, using "
+                        f"{options['arpeggio_note_duration_beats']}.{Style.RESET_ALL}"
                     )
 
         if not options["arpeggio_style"] and get_yes_no_answer(
@@ -252,7 +262,8 @@ class UIManager:
         ):
             try:
                 strum_in = safe_input(
-                    f"{Fore.CYAN}Strum delay between notes (milliseconds) [default: 15ms]: {Style.RESET_ALL}"
+                    f"{Fore.CYAN}Strum delay between notes (milliseconds) "
+                    f"[default: 15ms]: {Style.RESET_ALL}"
                 ).strip()
                 if strum_in:
                     options["strum_delay_ms"] = int(strum_in)

--- a/tests/test_chorderizer.py
+++ b/tests/test_chorderizer.py
@@ -1,13 +1,13 @@
 import os
 import sys
-import pytest
 from unittest.mock import MagicMock
 
 # Mock colorama and mido before importing chorderizer
-sys.modules['colorama'] = MagicMock()
-sys.modules['mido'] = MagicMock()
+sys.modules["colorama"] = MagicMock()
+sys.modules["mido"] = MagicMock()
 
-from chorderizer.chorderizer import _generate_midi_filename_helper
+from chorderizer.chorderizer import _generate_midi_filename_helper  # noqa: E402
+
 
 def test_generate_midi_filename_helper_basic():
     tonic = "C"
@@ -19,6 +19,7 @@ def test_generate_midi_filename_helper_basic():
 
     assert _generate_midi_filename_helper(tonic, scale_info, base_dir) == expected_path
 
+
 def test_generate_midi_filename_helper_with_spaces_in_tonic():
     tonic = "C # "
     scale_info = {"name": "Major"}
@@ -28,6 +29,7 @@ def test_generate_midi_filename_helper_with_spaces_in_tonic():
     expected_path = os.path.join(base_dir, expected_filename)
 
     assert _generate_midi_filename_helper(tonic, scale_info, base_dir) == expected_path
+
 
 def test_generate_midi_filename_helper_with_parentheses_and_spaces_in_scale():
     tonic = "D"
@@ -39,6 +41,7 @@ def test_generate_midi_filename_helper_with_parentheses_and_spaces_in_scale():
 
     assert _generate_midi_filename_helper(tonic, scale_info, base_dir) == expected_path
 
+
 def test_generate_midi_filename_helper_custom_prefix():
     tonic = "G"
     scale_info = {"name": "Dorian"}
@@ -48,7 +51,11 @@ def test_generate_midi_filename_helper_custom_prefix():
     expected_filename = "custom_G_Dorian.mid"
     expected_path = os.path.join(base_dir, expected_filename)
 
-    assert _generate_midi_filename_helper(tonic, scale_info, base_dir, prefix=prefix) == expected_path
+    assert (
+        _generate_midi_filename_helper(tonic, scale_info, base_dir, prefix=prefix)
+        == expected_path
+    )
+
 
 def test_generate_midi_filename_helper_empty_base_dir():
     tonic = "A"

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,12 +1,12 @@
-import pytest
 import sys
 from unittest.mock import MagicMock
 
 # Mock external dependencies
-sys.modules['mido'] = MagicMock()
+sys.modules["mido"] = MagicMock()
 
 from chorderizer.theory_utils import MusicTheory  # noqa: E402
-from chorderizer.generators import ChordGenerator
+from chorderizer.generators import ChordGenerator  # noqa: E402
+
 
 def test_chord_generator_happy_path():
     theory = MusicTheory()
@@ -16,7 +16,9 @@ def test_chord_generator_happy_path():
     scale_info = theory.AVAILABLE_SCALES["1"]
 
     # Default parameters: extension_level=2 (7ths), inversion=0
-    generated_chords, notes_names, notes_midi, base_qualities = generator.generate_scale_chords("C", scale_info)
+    generated_chords, notes_names, notes_midi, base_qualities = (
+        generator.generate_scale_chords("C", scale_info)
+    )
 
     assert "I" in generated_chords
     assert generated_chords["I"] == "Cmaj7"
@@ -27,44 +29,56 @@ def test_chord_generator_happy_path():
     assert generated_chords["ii"] == "Dm7"
     assert base_qualities["ii"] == "minor"
 
+
 def test_chord_generator_extension_levels():
     theory = MusicTheory()
     generator = ChordGenerator(theory)
-    scale_info = theory.AVAILABLE_SCALES["1"] # Major
+    scale_info = theory.AVAILABLE_SCALES["1"]  # Major
 
     # Triads (extension_level=0)
-    generated_chords, _, _, _ = generator.generate_scale_chords("C", scale_info, extension_level=0)
+    generated_chords, _, _, _ = generator.generate_scale_chords(
+        "C", scale_info, extension_level=0
+    )
     assert generated_chords["I"] == "C"
     assert generated_chords["ii"] == "Dm"
+
 
 def test_chord_generator_inversions():
     theory = MusicTheory()
     generator = ChordGenerator(theory)
-    scale_info = theory.AVAILABLE_SCALES["1"] # Major
+    scale_info = theory.AVAILABLE_SCALES["1"]  # Major
 
     # Root position (inversion=0)
-    _, _, notes_midi_root, _ = generator.generate_scale_chords("C", scale_info, inversion=0)
+    _, _, notes_midi_root, _ = generator.generate_scale_chords(
+        "C", scale_info, inversion=0
+    )
 
     # First inversion (inversion=1)
-    _, _, notes_midi_inv1, _ = generator.generate_scale_chords("C", scale_info, inversion=1)
+    _, _, notes_midi_inv1, _ = generator.generate_scale_chords(
+        "C", scale_info, inversion=1
+    )
 
     # Verify the lowest note in inversion 1 is different and higher than root position lowest note (or shifted)
     # The actual MIDI values depend on the specific octave selection logic, but we can verify
     # the relative pitch class or simply that the MIDI sequence is different.
     assert notes_midi_root["I"] != notes_midi_inv1["I"]
 
+
 def test_chord_generator_invalid_tonic():
     theory = MusicTheory()
     generator = ChordGenerator(theory)
-    scale_info = theory.AVAILABLE_SCALES["1"] # Major
+    scale_info = theory.AVAILABLE_SCALES["1"]  # Major
 
     # Invalid tonic
-    generated_chords, notes_names, notes_midi, base_qualities = generator.generate_scale_chords("Z", scale_info)
+    generated_chords, notes_names, notes_midi, base_qualities = (
+        generator.generate_scale_chords("Z", scale_info)
+    )
 
     assert generated_chords == {}
     assert notes_names == {}
     assert notes_midi == {}
     assert base_qualities == {}
+
 
 def test_chord_generator_caching():
     theory = MusicTheory()
@@ -87,18 +101,23 @@ def test_chord_generator_caching():
 # -----------------------------------------------------------------------------
 # VoiceLeader Tests
 # -----------------------------------------------------------------------------
-from chorderizer.generators import VoiceLeader
+from chorderizer.generators import VoiceLeader  # noqa: E402
 
 
 def test_voice_leader_reduces_motion():
     """Voice leading output should have less total movement than the raw jump."""
     # Cmaj7 -> Fmaj7 in raw root position
-    prev  = [60, 64, 67, 71]  # C4, E4, G4, B4
-    curr  = [65, 69, 72, 76]  # F4, A4, C5, E5
+    prev = [60, 64, 67, 71]  # C4, E4, G4, B4
+    curr = [65, 69, 72, 76]  # F4, A4, C5, E5
 
-    raw_motion = sum(abs(c - p) for c, p in zip(sorted(curr), sorted(prev)))
+    _ = sum(abs(c - p) for c, p in zip(sorted(curr), sorted(prev)))
     voiced = VoiceLeader.apply(prev, curr)
-    voiced_motion = sum(abs(v - p) for v in voiced for p in prev if abs(v - p) == min(abs(v - q) for q in prev))
+    _ = sum(
+        abs(v - p)
+        for v in voiced
+        for p in prev
+        if abs(v - p) == min(abs(v - q) for q in prev)
+    )
 
     # The voice-led version total span should be <= raw version
     assert max(voiced) - min(voiced) <= max(curr) - min(curr) + 12
@@ -106,14 +125,14 @@ def test_voice_leader_reduces_motion():
 
 def test_voice_leader_preserves_bass():
     """The bass note (lowest note, index 0) must not change pitch class."""
-    prev  = [48, 55, 60, 64]  # C3, G3, C4, E4
-    curr  = [53, 57, 60, 65]  # F3, A3, C4, F4
+    prev = [48, 55, 60, 64]  # C3, G3, C4, E4
+    curr = [53, 57, 60, 65]  # F3, A3, C4, F4
 
     voiced = VoiceLeader.apply(prev, curr)
 
     # Bass of curr is the first note (already sorted incoming)
     original_bass_pc = curr[0] % 12
-    result_bass_pc   = voiced[0] % 12
+    result_bass_pc = voiced[0] % 12
     assert result_bass_pc == original_bass_pc
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -2,16 +2,17 @@ import sys
 from unittest.mock import MagicMock
 
 # Mock colorama
-sys.modules['colorama'] = MagicMock()
-sys.modules['colorama.Fore'] = MagicMock()
-sys.modules['colorama.Style'] = MagicMock()
+sys.modules["colorama"] = MagicMock()
+sys.modules["colorama.Fore"] = MagicMock()
+sys.modules["colorama.Style"] = MagicMock()
 
 # Mock mido (needed by generators which is imported by chorderizer)
-sys.modules['mido'] = MagicMock()
+sys.modules["mido"] = MagicMock()
 
-import os
-import unittest
-from chorderizer.chorderizer import _sanitize_midi_path
+import os  # noqa: E402
+import unittest  # noqa: E402
+from chorderizer.chorderizer import _sanitize_midi_path  # noqa: E402
+
 
 class TestSecurity(unittest.TestCase):
     def setUp(self):
@@ -28,7 +29,9 @@ class TestSecurity(unittest.TestCase):
 
     def test_sanitize_path_traversal(self):
         # On Linux, os.path.basename("../../../etc/passwd") is "passwd"
-        result = _sanitize_midi_path("../../../etc/passwd", self.default_path, self.base_dir)
+        result = _sanitize_midi_path(
+            "../../../etc/passwd", self.default_path, self.base_dir
+        )
         self.assertEqual(result, os.path.join(self.base_dir, "passwd"))
 
     def test_sanitize_absolute_path(self):
@@ -38,8 +41,11 @@ class TestSecurity(unittest.TestCase):
 
     def test_sanitize_nested_traversal(self):
         # os.path.basename("subdir/../other.mid") is "other.mid"
-        result = _sanitize_midi_path("subdir/../other.mid", self.default_path, self.base_dir)
+        result = _sanitize_midi_path(
+            "subdir/../other.mid", self.default_path, self.base_dir
+        )
         self.assertEqual(result, os.path.join(self.base_dir, "other.mid"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_theory.py
+++ b/tests/test_theory.py
@@ -1,5 +1,6 @@
 import pytest
-from chorderizer.theory_utils import MusicTheoryUtils, MusicTheory
+from chorderizer.theory_utils import MusicTheoryUtils
+
 
 def test_get_note_index():
     assert MusicTheoryUtils.get_note_index("C") == 0
@@ -10,11 +11,13 @@ def test_get_note_index():
     with pytest.raises(ValueError):
         MusicTheoryUtils.get_note_index("Z")
 
+
 def test_get_note_name():
     assert MusicTheoryUtils.get_note_name(0) == "C"
     assert MusicTheoryUtils.get_note_name(1) == "C#"
     assert MusicTheoryUtils.get_note_name(1, use_flats=True) == "Db"
     assert MusicTheoryUtils.get_note_name(13) == "C#"
+
 
 def test_should_use_flats():
     assert MusicTheoryUtils.should_use_flats("F") is True
@@ -23,18 +26,20 @@ def test_should_use_flats():
     assert MusicTheoryUtils.should_use_flats("G") is False
     assert MusicTheoryUtils.should_use_flats("Eb Major") is True
 
+
 def test_split_chord_name():
     assert MusicTheoryUtils.split_chord_name("Cmaj7") == ("C", "maj7")
     assert MusicTheoryUtils.split_chord_name("F#m7") == ("F#", "m7")
     assert MusicTheoryUtils.split_chord_name("Bb7") == ("Bb", "7")
     assert MusicTheoryUtils.split_chord_name("G") == ("G", "")
 
+
 def test_transpose_chords():
     original_chords = {"I": "Cmaj7", "ii": "Dm7", "V": "G7"}
     # Transpose from C to D
     transposed = MusicTheoryUtils.transpose_chords(original_chords, "C", "D")
     assert transposed == {"I": "Dmaj7", "ii": "Em7", "V": "A7"}
-    
+
     # Transpose from C to F (should use flats)
     transposed_f = MusicTheoryUtils.transpose_chords(original_chords, "C", "F")
     assert transposed_f == {"I": "Fmaj7", "ii": "Gm7", "V": "C7"}


### PR DESCRIPTION
* **💡 What:** Replaced direct `input` calls with a `safe_input` wrapper and added consistent `Fore.CYAN` coloring to remaining unstyled user prompts.
* **🎯 Why:** Solves ugly stack tracebacks when users cancel using `Ctrl-C` or `Ctrl-D`, which is a jarring UX. Applying `Fore.CYAN` ensures visual consistency across the CLI for all prompts.
* **📸 Before/After:** CLI-only change, preventing stack traces like `KeyboardInterrupt` visually breaking the app.
* **♿ Accessibility:** Improved prompt contrast with `Fore.CYAN` and graceful exits make the CLI more intuitive and resilient.

---
*PR created automatically by Jules for task [242769778741179634](https://jules.google.com/task/242769778741179634) started by @julesklord*