### PR TITLE
🛡️ Sentinel: [LOW] Fix broad exception catching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Raw exception messages were printed to user output, potentially leaking sensitive system information such as paths or OS details.
 **Learning:** It is crucial to hide raw exception messages from users, providing only generic feedback, while logging the actual exception details securely for maintainers.
 **Prevention:** Always use a logging module to track exact errors, and display sanitized messages to end users.
+
+## 2024-05-20 - [Broad Exception Catching]
+**Vulnerability:** Catching the base `Exception` class in file saving logic could mask unexpected errors (e.g., `KeyboardInterrupt`, memory issues, or logic bugs) and lead to unpredictable program state.
+**Learning:** Catching specific exceptions (like `OSError` for file I/O) is essential for robust error handling and security, as it avoids swallowing unrelated system or logic failures.
+**Prevention:** Always catch the most specific exceptions possible for a given operation.

--- a/src/chorderizer/generators.py
+++ b/src/chorderizer/generators.py
@@ -558,7 +558,7 @@ class MidiGenerator:
             print(
                 f"\033[32mMIDI file '{output_filename}' generated successfully.\033[0m"
             )
-        except Exception as e:
+        except OSError as e:
             logging.error(f"Failed to save MIDI file '{output_filename}': {e}")
             print(
                 f"\033[31mError saving MIDI file '{output_filename}'. Please check permissions and path validity.\033[0m"


### PR DESCRIPTION
### 🛡️ Sentinel: [LOW] Fix broad exception catching

**Severity:** LOW
**Vulnerability:** Broad Exception Catching
**Impact:** Catching the base `Exception` class in file saving logic could mask unexpected errors (e.g., `KeyboardInterrupt`, memory issues, or logic bugs) and lead to unpredictable program state or difficult debugging.
**Fix:** Narrowed the exception catch scope to `OSError`, which is the appropriate base class for file I/O related errors in Python 3.
**Verification:** 
1. Created a temporary test script `tests/test_repro_fix.py` using `unittest.mock` to simulate both `OSError` and generic `Exception` during `midi_file.save()`.
2. Confirmed that `OSError` is still gracefully caught, logged, and reported to the user.
3. Confirmed that generic `Exception` now correctly bubbles up instead of being swallowed.
4. Ran existing security tests (`test_security.py`) to ensure no regressions.
5. Updated `.jules/sentinel.md` with the critical security learning.

---
*PR created automatically by Jules for task [11234586843869762316](https://jules.google.com/task/11234586843869762316) started by @julesklord*