### PR TITLE
🧹 Remove unnecessary 'pass' block and flatten tablature filter logic

### DIFF
--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -104,26 +104,23 @@ def process_single_run(
         )
 
         show_this_tab = False
-        if tab_display_filter_key == "8":
-            pass
-        elif tab_display_filter_key == "1":
+        if tab_display_filter_key == "1":
             show_this_tab = True
-        else:
-            if tab_display_filter_key == "2" and base_qual == "minor":
+        elif tab_display_filter_key == "2" and base_qual == "minor":
+            show_this_tab = True
+        elif tab_display_filter_key == "3" and "7" in chord_name_display:
+            show_this_tab = True
+        elif tab_display_filter_key == "4" and "9" in chord_name_display:
+            show_this_tab = True
+        elif tab_display_filter_key == "5":
+            if chord_name_display.endswith("6") and not chord_name_display.endswith(
+                "m7b6"
+            ):
                 show_this_tab = True
-            elif tab_display_filter_key == "3" and "7" in chord_name_display:
-                show_this_tab = True
-            elif tab_display_filter_key == "4" and "9" in chord_name_display:
-                show_this_tab = True
-            elif tab_display_filter_key == "5":
-                if chord_name_display.endswith("6") and not chord_name_display.endswith(
-                    "m7b6"
-                ):
-                    show_this_tab = True
-            elif tab_display_filter_key == "6" and "11" in chord_name_display:
-                show_this_tab = True
-            elif tab_display_filter_key == "7" and "13" in chord_name_display:
-                show_this_tab = True
+        elif tab_display_filter_key == "6" and "11" in chord_name_display:
+            show_this_tab = True
+        elif tab_display_filter_key == "7" and "13" in chord_name_display:
+            show_this_tab = True
 
         if show_this_tab and gen_midi_notes.get(degree):
             tab_lines_list = tab_builder.generate_simple_tab(


### PR DESCRIPTION
🎯 **What:**
- Removed a redundant `pass` block when `tab_display_filter_key` is `"8"`.
- Flattened a nested `else` structure into a single `if/elif` chain for the tablature filtering logic.

💡 **Why:**
- Improves code readability and maintainability by making the logic more idiomatic and easier to follow.
- Reduces nesting depth.

✅ **Verification:**
- Created a comprehensive verification script (`verify_refactor.py`) to confirm that the original and refactored logic yield identical results for all possible input combinations (all filter keys 1-8, various base qualities, and various chord names).
- Ran existing unit tests using `PYTHONPATH=src pytest` and all 23 tests passed.

✨ **Result:**
- Cleaner, more readable code with preserved functionality.

---
*PR created automatically by Jules for task [3378352442491001677](https://jules.google.com/task/3378352442491001677) started by @julesklord*