### PR TITLE
🧪 Add unit tests for `get_tablature_filter` in the UI module

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -7,6 +7,7 @@ sys.modules["mido"] = MagicMock()
 
 from chorderizer.ui import get_tablature_filter  # noqa: E402
 
+
 @patch("chorderizer.ui.get_numbered_option")
 def test_get_tablature_filter_valid_option(mock_get_numbered_option):
     """Test that when a user selects a valid option, it returns that option."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,29 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock external dependencies before importing local modules
+sys.modules["colorama"] = MagicMock()
+sys.modules["mido"] = MagicMock()
+
+from chorderizer.ui import get_tablature_filter  # noqa: E402
+
+@patch("chorderizer.ui.get_numbered_option")
+def test_get_tablature_filter_valid_option(mock_get_numbered_option):
+    """Test that when a user selects a valid option, it returns that option."""
+    mock_get_numbered_option.return_value = "1"
+
+    result = get_tablature_filter()
+
+    assert result == "1"
+    mock_get_numbered_option.assert_called_once()
+
+
+@patch("chorderizer.ui.get_numbered_option")
+def test_get_tablature_filter_cancelled(mock_get_numbered_option):
+    """Test that when a user cancels the selection, it defaults to returning '8'."""
+    mock_get_numbered_option.return_value = None
+
+    result = get_tablature_filter()
+
+    assert result == "8"
+    mock_get_numbered_option.assert_called_once()


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `get_tablature_filter` function in `src/chorderizer/ui.py`. This function relies on the `get_numbered_option` helper to read user input.

📊 **Coverage:**
- Tests the happy path: When the user selects a valid option (e.g. "1"), the function returns the selected option.
- Tests the edge/cancellation case: When the user cancels the selection (e.g. returns `None`), the function successfully defaults back to returning `"8"`.

✨ **Result:**
Improved test coverage for the UI module, making it much safer to refactor user input handling going forward. The implementation safely mocks `chorderizer.ui.get_numbered_option` to simulate input properly without relying on a full terminal interaction.

---
*PR created automatically by Jules for task [3579528273594701428](https://jules.google.com/task/3579528273594701428) started by @julesklord*