### PR TITLE
🧪 Add test for missing chord settings edge case

### DIFF
--- a/tests/test_chorderizer.py
+++ b/tests/test_chorderizer.py
@@ -1,7 +1,8 @@
 import os
 import sys
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock
 
 # Mock colorama and mido before importing chorderizer
 sys.modules["colorama"] = MagicMock()
@@ -67,3 +68,29 @@ def test_generate_midi_filename_helper_empty_base_dir():
     expected_path = os.path.join(base_dir, expected_filename)
 
     assert _generate_midi_filename_helper(tonic, scale_info, base_dir) == expected_path
+
+
+@patch("chorderizer.chorderizer.get_chord_settings")
+def test_process_single_run_missing_chord_settings(mock_get_chord_settings):
+    from chorderizer.chorderizer import process_single_run
+
+    # Setup mocks
+    ui_mock = MagicMock()
+    ui_mock.select_tonic_and_scale.return_value = ("C", {"name": "Major"})
+
+    chord_builder_mock = MagicMock()
+    tab_builder_mock = MagicMock()
+    midi_builder_mock = MagicMock()
+
+    # When get_chord_settings returns None
+    mock_get_chord_settings.return_value = None
+
+    # Act
+    result = process_single_run(
+        ui_mock, chord_builder_mock, tab_builder_mock, midi_builder_mock, "/tmp/midi"
+    )
+
+    # Assert
+    assert result is True
+    mock_get_chord_settings.assert_called_once()
+    chord_builder_mock.generate_scale_chords.assert_not_called()


### PR DESCRIPTION
🎯 **What:** Added a unit test to cover the edge case in `process_single_run` where the `get_chord_settings` helper returns `None`, indicating the user cancelled the action.
📊 **Coverage:** Specifically covers line 64 of `src/chorderizer/chorderizer.py`, verifying the early exit condition and that no further logic (like chord generation) is executed.
✨ **Result:** Improved test coverage by ensuring the code safely exits early when `get_chord_settings` returns `None`.

---
*PR created automatically by Jules for task [6693616444770702226](https://jules.google.com/task/6693616444770702226) started by @julesklord*