### PR TITLE
🎨 Palette: Graceful CLI Interruptions with POSIX 130 Exit Code

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-18 - Visual Styling Consistency
 **Learning:** Hardcoded raw ANSI escape codes (e.g., `\033[36m`) should be avoided in favor of cross-platform library constants (like `colorama`) for better maintainability and visual consistency. Similarly, wrapping all interactive CLI prompts (e.g., `input()`) in a distinct color helps users distinguish between standard application output and active interactive states.
 **Action:** When working on CLI apps, standardize colors using constants and ensure all interactive prompts are styled consistently.
+
+## 2025-02-23 - Exit Codes on CLI Interruption
+**Learning:** When catching `KeyboardInterrupt` or `EOFError` in nested CLI menus, swallowing the exception or returning `sys.exit(0)` is poor UX. Returning `sys.exit(0)` implies successful completion, messing up chaining in bash scripts. Swallowing it via `return None` can bypass outer protections, causing crashes further up the stack.
+**Action:** When users abort a CLI via interrupt signals, catch it gracefully to prevent ugly tracebacks, but always exit with `sys.exit(130)` (POSIX standard for SIGINT) to indicate intentional abortion.

--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -321,4 +321,4 @@ if __name__ == "__main__":
         main()
     except (EOFError, KeyboardInterrupt):
         print_operation_cancelled()
-        sys.exit(0)
+        sys.exit(130)

--- a/src/chorderizer/ui.py
+++ b/src/chorderizer/ui.py
@@ -34,7 +34,7 @@ def get_yes_no_answer(prompt: str) -> bool:
             )
         except (EOFError, KeyboardInterrupt):
             print_operation_cancelled()
-            sys.exit(0)
+            sys.exit(130)
 
 
 def get_numbered_option(
@@ -72,7 +72,7 @@ def get_numbered_option(
                 print(f"{Fore.RED}Invalid option.{Style.RESET_ALL}")
         except (EOFError, KeyboardInterrupt):
             print_operation_cancelled()
-            return None
+            sys.exit(130)
 
 
 def get_chord_settings() -> Tuple[Optional[int], Optional[int]]:

--- a/tests/test_chorderizer.py
+++ b/tests/test_chorderizer.py
@@ -79,7 +79,8 @@ def test_process_single_run_missing_scale_info():
 
     assert result is True
     ui_mock.select_tonic_and_scale.assert_called_once()
-    
+
+
 @patch("chorderizer.chorderizer.get_chord_settings")
 def test_process_single_run_missing_chord_settings(mock_get_chord_settings):
     from chorderizer.chorderizer import process_single_run


### PR DESCRIPTION
💡 **What:**
Updated the way the CLI application responds to keyboard interrupts (`Ctrl+C`) and `EOFError` (`Ctrl+D`). Previously, nested menus would either exit with code `0` (success) or swallow the interrupt by returning `None`, which could lead to an ugly stack trace (e.g., `TypeError`) higher up in the execution path. This has been unified to smoothly exit using POSIX standard exit code `130`.

🎯 **Why:**
Using exit code `0` when a script is aborted causes problems for shell scripts that rely on correct error codes (since the OS thinks the process finished successfully). Swallowing the interrupt in `get_numbered_option` resulted in an unhandled crash later. Exiting clearly with code `130` fixes these workflow bugs, keeping the user in a smooth, error-free flow even when canceling.

📸 **Before/After:**
*Before*: Pressing `Ctrl+C` inside the "Advanced MIDI Options" menu would print "Operation cancelled by the user" but then crash the app and print a messy Python `TypeError` stack trace to the screen.
*After*: The CLI cleanly catches the interrupt, tells the user the operation was aborted, and drops them back to their terminal cleanly with exit code 130.

♿ **Accessibility:**
A predictable and resilient interface. Keyboard-only users who abort standard flows now receive clean, safe exits without confusing developer logs polluting their screen readers.

*(Logged critical UX learning on handling terminal interruption codes in `.Jules/palette.md`)*

---
*PR created automatically by Jules for task [11832060532022602697](https://jules.google.com/task/11832060532022602697) started by @julesklord*