### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/Chorderizer/security/code-scanning/1](https://github.com/julesklord/Chorderizer/security/code-scanning/1)

Add an explicit workflow-level `permissions` block in `.github/workflows/python-package.yml` so all jobs inherit least-privilege token scope by default.

Best fix here (without changing functionality): insert
```yml
permissions:
  contents: read
```
immediately after the `on:` trigger section (before `jobs:`). This is sufficient for `actions/checkout` and for running lint/tests, and does not grant unnecessary write scopes.

No imports, methods, or external definitions are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
