### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/Chorderizer/security/code-scanning/2](https://github.com/julesklord/Chorderizer/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top level), so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the best minimal setting is:

- `contents: read`

This preserves existing functionality (`actions/checkout` and test/lint steps) while constraining token scope. No imports, methods, or dependencies are needed; just YAML configuration change near the top of the file (after `on:` section and before `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
