### PR TITLE
🧹 Remove unused parameters in MIDI generation tracks

### DIFF
--- a/src/chorderizer/generators.py
+++ b/src/chorderizer/generators.py
@@ -540,8 +540,6 @@ class MidiGenerator:
                     chord_midi_notes,
                     chord_duration_ticks,
                     midi_options,
-                    chord_data,
-                    ticks_per_beat,
                     arp_note_indiv_duration_ticks,
                 )
             else:  # Block chords (with optional strum)
@@ -550,8 +548,6 @@ class MidiGenerator:
                     chord_midi_notes,
                     chord_duration_ticks,
                     midi_options,
-                    chord_data,
-                    ticks_per_beat,
                     strum_delay_ticks,
                 )
 
@@ -578,8 +574,6 @@ class MidiGenerator:
         chord_midi_notes,
         chord_duration_ticks,
         midi_options,
-        chord_data,
-        ticks_per_beat,
         arp_note_indiv_duration_ticks,
     ):
         arp_notes_sequence = list(chord_midi_notes)
@@ -643,8 +637,6 @@ class MidiGenerator:
         chord_midi_notes,
         chord_duration_ticks,
         midi_options,
-        chord_data,
-        ticks_per_beat,
         strum_delay_ticks,
     ):
         time_offset_for_strum_completion = 0


### PR DESCRIPTION
🎯 **What:** Removed unused `chord_data` and `ticks_per_beat` parameters from `_generate_arpeggio_track` and `_generate_block_track` functions in `src/chorderizer/generators.py`.

💡 **Why:** Having unused parameters in function signatures creates dead code, which clutters the code and decreases maintainability.

✅ **Verification:** Ran flake8, black, and the full test suite via `pytest` to ensure no functional regressions.

✨ **Result:** Cleaner function signatures that only take the actually required arguments, making the code more readable and maintainable.

---
*PR created automatically by Jules for task [10798134676391899183](https://jules.google.com/task/10798134676391899183) started by @julesklord*