### PR TITLE
🧹 Remove unused arguments from `_generate_block_track`

### DIFF
--- a/src/chorderizer/generators.py
+++ b/src/chorderizer/generators.py
@@ -550,8 +550,6 @@ class MidiGenerator:
                     chord_midi_notes,
                     chord_duration_ticks,
                     midi_options,
-                    chord_data,
-                    ticks_per_beat,
                     strum_delay_ticks,
                 )
 
@@ -643,8 +641,6 @@ class MidiGenerator:
         chord_midi_notes,
         chord_duration_ticks,
         midi_options,
-        chord_data,
-        ticks_per_beat,
         strum_delay_ticks,
     ):
         time_offset_for_strum_completion = 0


### PR DESCRIPTION
🎯 **What:** Removed unused `chord_data` and `ticks_per_beat` arguments from the `_generate_block_track` method and its invocation in `src/chorderizer/generators.py`.
💡 **Why:** Having unused arguments in a method signature adds confusion and decreases readability. Removing them cleans up the codebase and simplifies the method's interface.
✅ **Verification:** Verified by checking that tests continue to pass and no unexpected behavior was introduced.
✨ **Result:** Improved readability and maintainability by simplifying the `_generate_block_track` signature without breaking functionality.

---
*PR created automatically by Jules for task [9608498890748171090](https://jules.google.com/task/9608498890748171090) started by @julesklord*