### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stack trace exposure on input interrupt

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Raw exception messages were printed to user output, potentially leaking sensitive system information such as paths or OS details.
 **Learning:** It is crucial to hide raw exception messages from users, providing only generic feedback, while logging the actual exception details securely for maintainers.
 **Prevention:** Always use a logging module to track exact errors, and display sanitized messages to end users.
+## 2024-05-24 - Gracefully Handle Interrupts to Avoid Stack Trace Leakage
+**Vulnerability:** Raw `input()` calls without exception handling expose raw stack traces when users interrupt the process (e.g., via `Ctrl+C` or `Ctrl+D`), which can leak internal application structure or paths.
+**Learning:** Always catch `EOFError` and `KeyboardInterrupt` specifically around CLI input prompts (or wrap them in a secure helper) to exit the application cleanly without dumping Python's internal exception stack to the console.
+**Prevention:** Use a wrapper function for `input()` that catches these exceptions and calls `sys.exit(0)`, or ensure every raw `input()` block is wrapped in `try...except (EOFError, KeyboardInterrupt):`.

--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -2,6 +2,7 @@ import os
 import random
 from typing import List, Dict, Tuple, Optional, Any
 import colorama
+import sys
 from colorama import Fore, Style
 
 # Imports from new modules
@@ -137,14 +138,18 @@ def process_single_run(
     if get_yes_no_answer(
         "Define a chord progression for MIDI? (If no, all diatonic chords will be used sequentially)"
     ):
-        progression_input_str = (
-            input(
-                "Enter progression (degrees separated by '-', e.g., I-V-vi-IV). "
-                "Optional duration in beats (e.g., I:4-V:2-vi:2-IV:4 ): "
+        try:
+            progression_input_str = (
+                input(
+                    "Enter progression (degrees separated by '-', e.g., I-V-vi-IV). "
+                    "Optional duration in beats (e.g., I:4-V:2-vi:2-IV:4 ): "
+                )
+                .strip()
+                .upper()
             )
-            .strip()
-            .upper()
-        )
+        except (EOFError, KeyboardInterrupt):
+            print_operation_cancelled()
+            sys.exit(0)
         progression_items = progression_input_str.split("-")
         for item_str in progression_items:
             item_str = item_str.strip()
@@ -198,9 +203,13 @@ def process_single_run(
         selected_scale_tonic, selected_scale_info, midi_export_default_dir
     )
 
-    output_midi_filename = input(
-        f"Enter MIDI filename [default: {suggested_midi_path}]: "
-    ).strip()
+    try:
+        output_midi_filename = input(
+            f"Enter MIDI filename [default: {suggested_midi_path}]: "
+        ).strip()
+    except (EOFError, KeyboardInterrupt):
+        print_operation_cancelled()
+        sys.exit(0)
     if not output_midi_filename:
         output_midi_filename = suggested_midi_path
     else:
@@ -264,9 +273,13 @@ def process_single_run(
                                 midi_export_default_dir,
                                 prefix="prog_TRANSP_",
                             )
-                            trans_midi_fname_out = input(
-                                f"Enter transposed MIDI filename [default: {sugg_trans_path}]: "
-                            ).strip()
+                            try:
+                                trans_midi_fname_out = input(
+                                    f"Enter transposed MIDI filename [default: {sugg_trans_path}]: "
+                                ).strip()
+                            except (EOFError, KeyboardInterrupt):
+                                print_operation_cancelled()
+                                sys.exit(0)
                             if not trans_midi_fname_out:
                                 trans_midi_fname_out = sugg_trans_path
                             else:

--- a/src/chorderizer/ui.py
+++ b/src/chorderizer/ui.py
@@ -181,6 +181,9 @@ class UIManager:
                 )
             if options["bpm"] <= 0:
                 options["bpm"] = 120  # Fallback
+        except (EOFError, KeyboardInterrupt):
+            print_operation_cancelled()
+            sys.exit(0)
         except ValueError:
             print(f"{Fore.RED}Invalid BPM, using {options['bpm']}.{Style.RESET_ALL}")
 
@@ -191,6 +194,9 @@ class UIManager:
             if vel_in:
                 options["base_velocity"] = int(vel_in)
             options["base_velocity"] = max(0, min(127, options["base_velocity"]))
+        except (EOFError, KeyboardInterrupt):
+            print_operation_cancelled()
+            sys.exit(0)
         except ValueError:
             print(
                 f"{Fore.RED}Invalid velocity, using {options['base_velocity']}.{Style.RESET_ALL}"
@@ -204,6 +210,9 @@ class UIManager:
                 options["velocity_randomization_range"] = max(
                     0, min(20, options["velocity_randomization_range"])
                 )
+            except (EOFError, KeyboardInterrupt):
+                print_operation_cancelled()
+                sys.exit(0)
             except ValueError:
                 print(f"{Fore.RED}Invalid range, using 0.{Style.RESET_ALL}")
 
@@ -234,6 +243,9 @@ class UIManager:
                         options["arpeggio_note_duration_beats"] = float(arp_dur_in)
                     if options["arpeggio_note_duration_beats"] <= 0:
                         options["arpeggio_note_duration_beats"] = 0.25
+                except (EOFError, KeyboardInterrupt):
+                    print_operation_cancelled()
+                    sys.exit(0)
                 except ValueError:
                     print(
                         f"{Fore.RED}Invalid arpeggio note duration, using {options['arpeggio_note_duration_beats']}.{Style.RESET_ALL}"
@@ -251,6 +263,9 @@ class UIManager:
                 options["strum_delay_ms"] = max(
                     0, min(100, options["strum_delay_ms"])
                 )  # Cap delay
+            except (EOFError, KeyboardInterrupt):
+                print_operation_cancelled()
+                sys.exit(0)
             except ValueError:
                 print(f"{Fore.RED}Invalid strum delay, using 0.{Style.RESET_ALL}")
 


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Multiple `input()` prompts lack handling for `EOFError` or `KeyboardInterrupt`. When a user interrupts the prompt (via `Ctrl+D` or `Ctrl+C`), Python dumps an ugly, raw stack trace to the console. This can inadvertently leak sensitive internal application structure or paths to the user.
🎯 **Impact**: Information Disclosure (stack traces) and poor user experience when exiting forcefully.
🔧 **Fix**: Added explicit `except (EOFError, KeyboardInterrupt):` blocks to wrap vulnerable raw `input()` calls in `src/chorderizer/ui.py` and `src/chorderizer/chorderizer.py`. These blocks invoke a standardized `print_operation_cancelled()` message and cleanly shut down the process via `sys.exit(0)`.
✅ **Verification**: Run `PYTHONPATH=src python3 -m chorderizer` and press `Ctrl+C` or `Ctrl+D` during `input()` prompts (e.g. entering MIDI filename, typing BPM, etc). The application will cleanly print a cancellation message and exit gracefully rather than throwing a stack trace. Tests have been successfully run.

---
*PR created automatically by Jules for task [18001434546674322886](https://jules.google.com/task/18001434546674322886) started by @julesklord*