### PR TITLE
🎨 Palette: Align list items in UI menus

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-15 - Aligning list items in CLI menus
+**Learning:** Raw textual lines for list items with varying lengths of numbers (e.g., 1-12) can be misaligned, making scanning and comparing values difficult. Padding option numbers dynamically using `rjust` improves the UX significantly.
+**Action:** Always right-justify option numbers or format them into a fixed-width table structure when presenting dense list data in CLI menus to improve visual alignment and scannability.

--- a/src/chorderizer/ui.py
+++ b/src/chorderizer/ui.py
@@ -51,14 +51,18 @@ def get_numbered_option(
     print(f"\n{Fore.CYAN}{prompt}{Style.RESET_ALL}")
     display_options = {str(k): v for k, v in options.items()}
 
+    max_key_len = max(len(str(k)) for k in display_options.keys()) if display_options else 1
+    if allow_cancel:
+        max_key_len = max(max_key_len, len(cancel_key))
+
     for key_str, value in display_options.items():
         display_name = (
             value.get("name", value) if isinstance(value, dict) else str(value)
         )
-        print(f"  {key_str}. {display_name}")
+        print(f"  {key_str.rjust(max_key_len)}. {display_name}")
 
     if allow_cancel:
-        print(f"  {cancel_key}. {Fore.RED}Cancel / Back{Style.RESET_ALL}")
+        print(f"  {cancel_key.rjust(max_key_len)}. {Fore.RED}Cancel / Back{Style.RESET_ALL}")
 
     while True:
         try:


### PR DESCRIPTION
**💡 What:** 
Dynamically calculates the maximum length of keys in `get_numbered_option` menus (e.g., scale tonic selection) and right-justifies them.

**🎯 Why:**
When a list contains items from 1 to 12 (like the scale selection), the varying length of the numbers causes the text that follows to become misaligned. By aligning the numbers to the right (padding the left), the list becomes significantly easier to scan and compare.

**📸 Before/After:**
*Before:*
```
  1. C
  2. C#
...
  9. G#
  10. A
  11. A#
```
*After:*
```
   1. C
   2. C#
...
   9. G#
  10. A
  11. A#
```

**♿ Accessibility:**
Improves visual cognitive load and scannability, benefiting all users but particularly those with visual tracking or reading difficulties.

---
*PR created automatically by Jules for task [11610066717984339888](https://jules.google.com/task/11610066717984339888) started by @julesklord*