### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,5 +1,7 @@
 ﻿name: Python CI (Pro)
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/chorderizer/security/code-scanning/3](https://github.com/julesklord/chorderizer/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access.  
For this workflow, the minimal and sufficient permission is:

- `contents: read`

This should be inserted in `.github/workflows/python-ci.yml` directly under the `on:` declaration (or under `name:`), before `jobs:`. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
