### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,7 @@
 ﻿name: Security Scan
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   gitleaks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julesklord/chorderizer/security/code-scanning/4](https://github.com/julesklord/chorderizer/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here (without changing behavior) is to set workflow-level permissions to:

- `contents: read`

This applies to all jobs in this workflow (currently only `gitleaks`) and satisfies the CodeQL recommendation. Edit `.github/workflows/security.yml` near the top-level keys, placing `permissions` after `on` (or before `jobs`) with proper YAML indentation.

No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
