### PR TITLE
🎨 Palette: Make EXPORT MIDI button interactive and teach hotkeys

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-29 - Interactive Buttons Need Handlers in Textual
+**Learning:** In Textual TUIs, visual buttons (like `Button("Export", id="btn-export")`) do not automatically execute the app's predefined action bindings even if they visually suggest a global action. They require an explicit `on_button_pressed` event handler to wire them to the underlying action. Additionally, adding `tooltip` properties to these buttons is an excellent way to teach users the equivalent keyboard shortcut (e.g., "Hotkey: E"), bridging the gap between mouse exploration and keyboard efficiency.
+**Action:** Always verify that interactive visual elements in Textual apps have explicit event handlers mapped, and utilize tooltips on buttons to educate users about faster keyboard workflows.

--- a/src/chorderizer/generators.py
+++ b/src/chorderizer/generators.py
@@ -540,7 +540,7 @@ class MidiGenerator:
         prev_chord_midi: Optional[List[int]] = None
 
         for chord_data in chords_to_process:
-            chord_midi_notes = chord_data["notas_midi"]
+            chord_midi_notes = chord_data.get("notas_midi", chord_data.get("midi_notes", []))
             if not chord_midi_notes:
                 continue
 
@@ -549,7 +549,9 @@ class MidiGenerator:
 
             prev_chord_midi = list(chord_midi_notes)
 
-            chord_duration_beats = chord_data["duracion_beats"]
+            chord_duration_beats = chord_data.get(
+                "duracion_beats", chord_data.get("duration_beats", 4.0)
+            )
             chord_duration_ticks = int(chord_duration_beats * ticks_per_beat)
 
             if bass_track and midi_options.get("add_bass_track", False):

--- a/src/chorderizer/tui_app.py
+++ b/src/chorderizer/tui_app.py
@@ -201,7 +201,13 @@ class ChorderizerApp(App):
                     yield RadioButton("1st")
                     yield RadioButton("2nd")
                     yield RadioButton("3rd")
-                yield Button("EXPORT MIDI", variant="primary", id="btn-export", classes="mt-2")
+                yield Button(
+                    "EXPORT MIDI",
+                    variant="primary",
+                    id="btn-export",
+                    classes="mt-2",
+                    tooltip="Export progression to MIDI (Hotkey: E)",
+                )
 
             with Vertical(id="center-col"):
                 yield PianoWidget(id="piano")
@@ -243,6 +249,10 @@ class ChorderizerApp(App):
 
     def on_radio_set_changed(self) -> None:
         self.update_chords()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-export":
+            self.action_export_midi()
 
     def on_data_table_row_selected(self) -> None:
         self.action_add_to_progression()


### PR DESCRIPTION
- Added tooltip to EXPORT MIDI button teaching the 'E' hotkey
- Wired up on_button_pressed event handler so the button actually works
- Fixed dictionary key mismatch in MIDI generator when calling export from the button action
- Initialized palette.md journal with insight on Textual button events