### PR TITLE
feat(ux): Add mouse click support and tooltip to export button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-24 - Textual TUI Button Wiring
+**Learning:** In the Textual TUI framework, action buttons (like "EXPORT MIDI") might only be bound to keyboard shortcuts initially. They do not automatically trigger the associated keyboard action when clicked with a mouse unless an explicit `on_button_pressed` event handler is wired up.
+**Action:** Always check TUI buttons to ensure they have both keyboard bindings and proper `on_button_pressed` event handlers for mouse users, and consider adding tooltips for better interaction clarity.

--- a/src/chorderizer/tui_app.py
+++ b/src/chorderizer/tui_app.py
@@ -201,7 +201,13 @@ class ChorderizerApp(App):
                     yield RadioButton("1st")
                     yield RadioButton("2nd")
                     yield RadioButton("3rd")
-                yield Button("EXPORT MIDI", variant="primary", id="btn-export", classes="mt-2")
+                yield Button(
+                    "EXPORT MIDI",
+                    variant="primary",
+                    id="btn-export",
+                    classes="mt-2",
+                    tooltip="Export progression to MIDI file"
+                )
 
             with Vertical(id="center-col"):
                 yield PianoWidget(id="piano")
@@ -246,6 +252,10 @@ class ChorderizerApp(App):
 
     def on_data_table_row_selected(self) -> None:
         self.action_add_to_progression()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-export":
+            self.action_export_midi()
 
     def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
         degree = event.row_key.value


### PR DESCRIPTION
Adds a tooltip to the 'EXPORT MIDI' button for better discoverability and implements an `on_button_pressed` event handler to ensure the action is accessible via mouse click, not just the `[E]` keyboard shortcut.