### PR TITLE
feat(ux): Add tooltip and mouse click support for EXPORT MIDI button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-17 - Textual Button Interactions
+**Learning:** In Textual TUI applications, buttons don't magically connect to actions unless explicitly wired up using `on_button_pressed` handlers. We had an EXPORT MIDI button that looked interactive but did not trigger an action when clicked via mouse (only worked via keyboard shortcut bindings). Tooltips are also an easy addition to primary buttons via the `tooltip` property to increase accessibility and clarify shortcuts.
+**Action:** Always check if interactive UI components in Textual have actual event handlers backing them, and add tooltips for primary buttons.

--- a/src/chorderizer/generators.py
+++ b/src/chorderizer/generators.py
@@ -540,7 +540,7 @@ class MidiGenerator:
         prev_chord_midi: Optional[List[int]] = None
 
         for chord_data in chords_to_process:
-            chord_midi_notes = chord_data["notas_midi"]
+            chord_midi_notes = chord_data["midi_notes"]
             if not chord_midi_notes:
                 continue
 
@@ -549,7 +549,7 @@ class MidiGenerator:
 
             prev_chord_midi = list(chord_midi_notes)
 
-            chord_duration_beats = chord_data["duracion_beats"]
+            chord_duration_beats = chord_data["duration_beats"]
             chord_duration_ticks = int(chord_duration_beats * ticks_per_beat)
 
             if bass_track and midi_options.get("add_bass_track", False):

--- a/src/chorderizer/tui_app.py
+++ b/src/chorderizer/tui_app.py
@@ -201,7 +201,13 @@ class ChorderizerApp(App):
                     yield RadioButton("1st")
                     yield RadioButton("2nd")
                     yield RadioButton("3rd")
-                yield Button("EXPORT MIDI", variant="primary", id="btn-export", classes="mt-2")
+                yield Button(
+                    "EXPORT MIDI",
+                    variant="primary",
+                    id="btn-export",
+                    classes="mt-2",
+                    tooltip="Export current progression to MIDI file (Shortcut: E)",
+                )
 
             with Vertical(id="center-col"):
                 yield PianoWidget(id="piano")
@@ -243,6 +249,10 @@ class ChorderizerApp(App):
 
     def on_radio_set_changed(self) -> None:
         self.update_chords()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-export":
+            self.action_export_midi()
 
     def on_data_table_row_selected(self) -> None:
         self.action_add_to_progression()


### PR DESCRIPTION
* Add `tooltip` attribute to "EXPORT MIDI" button indicating the keyboard shortcut
* Wire up `on_button_pressed` handler in `tui_app.py` to trigger MIDI export action on click
* Fix translation key errors in `generators.py` preventing MIDI generation (`notas_midi` -> `midi_notes`, `duracion_beats` -> `duration_beats`)
* Document findings in `.Jules/palette.md`