### PR TITLE
feat(ux): Add empty state to ProgressionPanel and tooltips to core co…

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Empty States and Tooltips
+**Learning:** Empty states provide crucial context for user interaction in TUI applications, specifically in the `ProgressionPanel` where users might not realize the need to use a hotkey to start building their progression. Tooltips significantly increase discoverability for icon buttons and configuration selectors.
+**Action:** Always add an empty state for list/collection views and include descriptive tooltips for primary action buttons or dense configuration panels. Use the Textual `display` property to toggle visibility between the empty state and the content.

--- a/src/chorderizer/tui_app.py
+++ b/src/chorderizer/tui_app.py
@@ -179,13 +179,17 @@ class ChorderizerApp(App):
             with Vertical(id="sidebar"):
                 yield Label("TONIC", classes="config-label")
                 yield Select(
-                    [(n, n) for n in self.theory.CHROMATIC_NOTES], id="tonic-select", value="C"
+                    [(n, n) for n in self.theory.CHROMATIC_NOTES],
+                    id="tonic-select",
+                    value="C",
+                    tooltip="Select the root note for the scale",
                 )
                 yield Label("SCALE", classes="config-label")
                 yield Select(
                     [(v["name"], k) for k, v in self.theory.AVAILABLE_SCALES.items()],
                     id="scale-select",
                     value="1",
+                    tooltip="Select the scale/mode to generate chords from",
                 )
                 yield Label("EXTENSIONS", classes="config-label")
                 with RadioSet(id="extension-set"):
@@ -201,7 +205,13 @@ class ChorderizerApp(App):
                     yield RadioButton("1st")
                     yield RadioButton("2nd")
                     yield RadioButton("3rd")
-                yield Button("EXPORT MIDI", variant="primary", id="btn-export", classes="mt-2")
+                yield Button(
+                    "EXPORT MIDI",
+                    variant="primary",
+                    id="btn-export",
+                    classes="mt-2",
+                    tooltip="Export progression to a MIDI file (E)",
+                )
 
             with Vertical(id="center-col"):
                 yield PianoWidget(id="piano")

--- a/src/chorderizer/tui_widgets.py
+++ b/src/chorderizer/tui_widgets.py
@@ -174,6 +174,12 @@ class ProgressionPanel(Static):
     #prog-list {
         height: 1fr;
     }
+    #prog-empty {
+        height: 1fr;
+        content-align: center middle;
+        text-align: center;
+        color: $text-muted;
+    }
     .prog-header {
         background: $accent;
         color: $text-primary;
@@ -190,14 +196,24 @@ class ProgressionPanel(Static):
 
     def compose(self) -> ComposeResult:
         yield Label("PROGRESSION", classes="prog-header")
+        yield Label("Your progression is empty...\nPress [A] to add chords", id="prog-empty")
         yield ListView(id="prog-list")
         yield Label(" [bold][A][/bold] Add  [bold][X][/bold] Clear", id="prog-help")
 
+    def on_mount(self):
+        self.query_one("#prog-list").display = False
+
     def add_chord(self, chord_data: Dict[str, Any]):
-        self.query_one("#prog-list", ListView).append(ProgressionItem(chord_data))
+        self.query_one("#prog-empty").display = False
+        list_view = self.query_one("#prog-list", ListView)
+        list_view.display = True
+        list_view.append(ProgressionItem(chord_data))
 
     def clear_prog(self):
-        self.query_one("#prog-list", ListView).clear()
+        list_view = self.query_one("#prog-list", ListView)
+        list_view.clear()
+        list_view.display = False
+        self.query_one("#prog-empty").display = True
 
     def get_progression_data(self) -> List[Dict[str, Any]]:
         return [


### PR DESCRIPTION
…ntrols

- Added an informative empty state label to the ProgressionPanel that toggles visibility when chords are added or cleared.
- Added descriptive tooltips to the TONIC and SCALE selectors, as well as the EXPORT MIDI button, improving discoverability.