### PR TITLE
🎨 Palette: Add helpful empty state to progression list

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-20 - Helpful Empty States in Textual
+**Learning:** Textual TUI widgets greatly benefit from explicit empty states, especially lists and panels, to guide the user on how to interact with the dashboard. The `display: none;` CSS property toggled via `.add_class("hidden")` and `.remove_class("hidden")` works perfectly for this.
+**Action:** Always implement empty states for data containers in TUI applications to enhance onboarding and user guidance.

--- a/src/chorderizer/tui_widgets.py
+++ b/src/chorderizer/tui_widgets.py
@@ -186,18 +186,31 @@ class ProgressionPanel(Static):
         padding: 1;
         background: $surface;
     }
+    #prog-empty {
+        text-align: center;
+        padding: 2;
+        color: $text-muted;
+    }
+    #prog-empty.hidden {
+        display: none;
+    }
     """
 
     def compose(self) -> ComposeResult:
         yield Label("PROGRESSION", classes="prog-header")
+        yield Label(
+            "No chords yet.\nSelect a chord and\npress [bold][A][/bold] to add it.", id="prog-empty"
+        )
         yield ListView(id="prog-list")
         yield Label(" [bold][A][/bold] Add  [bold][X][/bold] Clear", id="prog-help")
 
     def add_chord(self, chord_data: Dict[str, Any]):
+        self.query_one("#prog-empty", Label).add_class("hidden")
         self.query_one("#prog-list", ListView).append(ProgressionItem(chord_data))
 
     def clear_prog(self):
         self.query_one("#prog-list", ListView).clear()
+        self.query_one("#prog-empty", Label).remove_class("hidden")
 
     def get_progression_data(self) -> List[Dict[str, Any]]:
         return [


### PR DESCRIPTION
Added an empty state label to the ProgressionPanel to provide clear guidance to users when the chord list is empty. The message dynamically hides and shows when chords are added or cleared.

Fixes #missing-empty-state