### PR TITLE
feat(ui): add empty state to progression panel and tooltip to export …

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Textual TUI Empty States
+**Learning:** In the Textual framework, managing empty states in lists (like `ListView`) requires explicitly toggling the `.display` property (boolean) between the empty indicator widget (e.g. `Label`) and the list widget itself. Textual doesn't have a built-in "empty placeholder" for iterables that handles this automatically yet.
+**Action:** Always create a companion widget for the empty state with `display: none` in CSS initially, and manually toggle `self.query_one("#widget-id").display = False/True` in the methods that add/remove items.

--- a/src/chorderizer/tui_app.py
+++ b/src/chorderizer/tui_app.py
@@ -201,7 +201,13 @@ class ChorderizerApp(App):
                     yield RadioButton("1st")
                     yield RadioButton("2nd")
                     yield RadioButton("3rd")
-                yield Button("EXPORT MIDI", variant="primary", id="btn-export", classes="mt-2")
+                yield Button(
+                    "EXPORT MIDI",
+                    variant="primary",
+                    id="btn-export",
+                    classes="mt-2",
+                    tooltip="Export current composition to MIDI",
+                )
 
             with Vertical(id="center-col"):
                 yield PianoWidget(id="piano")

--- a/src/chorderizer/tui_widgets.py
+++ b/src/chorderizer/tui_widgets.py
@@ -173,6 +173,14 @@ class ProgressionPanel(Static):
     }
     #prog-list {
         height: 1fr;
+        display: none;
+    }
+    #prog-empty {
+        height: 1fr;
+        content-align: center middle;
+        text-align: center;
+        color: $text-muted;
+        padding: 1;
     }
     .prog-header {
         background: $accent;
@@ -190,14 +198,21 @@ class ProgressionPanel(Static):
 
     def compose(self) -> ComposeResult:
         yield Label("PROGRESSION", classes="prog-header")
+        yield Label(
+            "Progression is empty.\n\nSelect a chord and press [A] to add it.", id="prog-empty"
+        )
         yield ListView(id="prog-list")
         yield Label(" [bold][A][/bold] Add  [bold][X][/bold] Clear", id="prog-help")
 
     def add_chord(self, chord_data: Dict[str, Any]):
+        self.query_one("#prog-empty").display = False
+        self.query_one("#prog-list").display = True
         self.query_one("#prog-list", ListView).append(ProgressionItem(chord_data))
 
     def clear_prog(self):
         self.query_one("#prog-list", ListView).clear()
+        self.query_one("#prog-list").display = False
+        self.query_one("#prog-empty").display = True
 
     def get_progression_data(self) -> List[Dict[str, Any]]:
         return [


### PR DESCRIPTION
…button

🎨 Palette UX improvements:
- Added a helpful empty state message to the ProgressionPanel when no chords have been added yet, guiding the user on how to interact with it.
- Added a descriptive tooltip to the "EXPORT MIDI" button to clarify its action.