### PR TITLE
🎨 Palette: Add tooltip and functional action to EXPORT MIDI button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Missing Button Handlers and Tooltips in Textual TUI
+**Learning:** Found that visual buttons in Textual (`yield Button(...)`) may be disconnected from their underlying actions if not explicitly wired via `on_button_pressed` or `@on(Button.Pressed)`. Adding tooltips explaining not just the action but the keyboard shortcut significantly improves discoverability in keyboard-heavy interfaces.
+**Action:** When adding buttons to Textual apps, always ensure they are wired up in an event handler and have a descriptive tooltip, especially if there's a corresponding keyboard binding.

--- a/src/chorderizer/tui_app.py
+++ b/src/chorderizer/tui_app.py
@@ -201,7 +201,13 @@ class ChorderizerApp(App):
                     yield RadioButton("1st")
                     yield RadioButton("2nd")
                     yield RadioButton("3rd")
-                yield Button("EXPORT MIDI", variant="primary", id="btn-export", classes="mt-2")
+                yield Button(
+                    "EXPORT MIDI",
+                    variant="primary",
+                    id="btn-export",
+                    classes="mt-2",
+                    tooltip="Export progression to MIDI file (E)",
+                )
 
             with Vertical(id="center-col"):
                 yield PianoWidget(id="piano")
@@ -243,6 +249,10 @@ class ChorderizerApp(App):
 
     def on_radio_set_changed(self) -> None:
         self.update_chords()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-export":
+            self.action_export_midi()
 
     def on_data_table_row_selected(self) -> None:
         self.action_add_to_progression()


### PR DESCRIPTION
💡 What:
- Added a descriptive tooltip to the "EXPORT MIDI" button.
- Implemented `on_button_pressed` event handler to actually trigger the `action_export_midi` when the button is clicked.

🎯 Why:
- The "EXPORT MIDI" button was visually present but functionally disconnected (clicking it did nothing).
- The tooltip clarifies what the button does and mentions the (E) keyboard shortcut, improving interface discoverability.

♿ Accessibility:
- Added `tooltip="Export progression to MIDI file (E)"` for screen readers and visual guidance.
- Keyboard functionality and mouse functionality are now aligned.