### PR TITLE
🎨 Palette: Add UX tooltips to interactive dashboard elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,1 @@
+## 2024-05-24 - Textual TUI Tooltips\n**Learning:** The textual Python TUI library supports `tooltip` keyword argument natively for Widgets, improving accessibility for interactive widgets like `Select` and `Button`.\n**Action:** Add `tooltip` argument on TUI elements where context or keyboard shortcuts could be provided via hover.

--- a/src/chorderizer/tui_app.py
+++ b/src/chorderizer/tui_app.py
@@ -179,13 +179,14 @@ class ChorderizerApp(App):
             with Vertical(id="sidebar"):
                 yield Label("TONIC", classes="config-label")
                 yield Select(
-                    [(n, n) for n in self.theory.CHROMATIC_NOTES], id="tonic-select", value="C"
+                    [(n, n) for n in self.theory.CHROMATIC_NOTES], id="tonic-select", value="C", tooltip="Select Root Note"
                 )
                 yield Label("SCALE", classes="config-label")
                 yield Select(
                     [(v["name"], k) for k, v in self.theory.AVAILABLE_SCALES.items()],
                     id="scale-select",
                     value="1",
+                    tooltip="Select Musical Scale"
                 )
                 yield Label("EXTENSIONS", classes="config-label")
                 with RadioSet(id="extension-set"):
@@ -201,7 +202,7 @@ class ChorderizerApp(App):
                     yield RadioButton("1st")
                     yield RadioButton("2nd")
                     yield RadioButton("3rd")
-                yield Button("EXPORT MIDI", variant="primary", id="btn-export", classes="mt-2")
+                yield Button("EXPORT MIDI", variant="primary", id="btn-export", classes="mt-2", tooltip="Export progression to MIDI file (Shortcut: E)")
 
             with Vertical(id="center-col"):
                 yield PianoWidget(id="piano")


### PR DESCRIPTION
💡 What: Added informative `tooltip` properties to the `Select` (Tonic and Scale) dropdowns and the Export MIDI `Button`.
🎯 Why: To make the interface more intuitive and reveal keyboard shortcuts (like 'E' for Export MIDI) without requiring the user to open the manual.
♿ Accessibility: Provides helpful context on hover for screen reader and pointer users.