### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix stack trace leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Raw exception strings (e.g. `except ValueError as e: print(f"...{e}")`) were directly exposed to end users via CLI output.
 **Learning:** Returning or printing exact system exceptions to the user UI interface can unintentionally leak sensitive system paths, execution states, or dependency logic details.
 **Prevention:** Catch the exception, securely log the detailed information using `logging.error(f"...{e}")` for internal monitoring, and display a safe, generalized error message to the end user.
+
+## 2026-04-18 - Stop exposing stack traces
+**Vulnerability:** traceback.print_exc() was exposing local stack traces on failure.
+**Learning:** Even in local CLI/TUI apps, showing traceback.print_exc() violates the principle of not exposing internal stack traces.
+**Prevention:** Use logging.error('...', exc_info=False) and display a user-friendly error instead.

--- a/src/chorderizer/chorderizer.py
+++ b/src/chorderizer/chorderizer.py
@@ -48,10 +48,10 @@ def run_modern_tui():
         render_warn("Make sure you are running from the src directory or have it in PYTHONPATH.")
         sys.exit(1)
     except Exception as e:
-        render_error(f"Failed to launch dashboard: {e}")
-        import traceback
-
-        traceback.print_exc()
+        # Sentinel Security: Do not expose stack trace or raw exception
+        render_error("Failed to launch dashboard.")
+        import logging
+        logging.error(f"Failed to launch dashboard: {e}")
         sys.exit(1)
 
 


### PR DESCRIPTION
Replaced traceback.print_exc() with a generic error message for the user, while securely logging the actual exception message via logging.error to prevent leaking sensitive system and path information to the end-user.